### PR TITLE
cfmanager improvements

### DIFF
--- a/contracts/asset/Asset.sol
+++ b/contracts/asset/Asset.sol
@@ -92,6 +92,7 @@ contract Asset is IAsset, ERC20Snapshot {
         IIssuerCommon issuer = _issuer();
         require(
             state.transferable ||
+            (to == state.owner) ||
             (from == address(this) && issuer.isWalletApproved(to)) ||
             (to == address(this) && issuer.isWalletApproved(from)) ||
             (from == state.owner && _campaignWhitelisted(to)) ||

--- a/contracts/managers/ACfManager.sol
+++ b/contracts/managers/ACfManager.sol
@@ -1,0 +1,340 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "../shared/Structs.sol";
+import "../tokens/erc20/IToken.sol";
+import "../shared/IAssetCommon.sol";
+import "../shared/IIssuerCommon.sol";
+import "../shared/ICampaignCommon.sol";
+
+abstract contract ACfManager is IVersioned, ICampaignCommon {
+    using SafeERC20 for IERC20;
+
+    //------------------------
+    //  STATE
+    //------------------------
+    Structs.CfManagerState internal state;
+    Structs.InfoEntry[] internal infoHistory;
+    mapping (address => uint256) internal claims;
+    mapping (address => uint256) internal investments;
+    mapping (address => uint256) internal tokenAmounts;
+
+    //------------------------
+    //  EVENTS
+    //------------------------
+    event Invest(
+        address indexed investor,
+        address asset,
+        uint256 tokenAmount,
+        uint256 tokenValue,
+        uint256 timestamp
+    );
+    event Claim(
+        address indexed investor,
+        address asset,
+        uint256 tokenAmount,
+        uint256 tokenValue,
+        uint256 timestamp
+    );
+    event CancelInvestment(
+        address indexed investor,
+        address asset,
+        uint256 tokenAmount,
+        uint256 tokenValue,
+        uint256 timestamp
+    );
+    event Finalize(
+        address indexed owner,
+        address asset,
+        uint256 fundsRaised,
+        uint256 tokensSold,
+        uint256 tokensRefund,
+        uint256 timestamp
+    );
+    event CancelCampaign(address indexed owner, address asset, uint256 tokensReturned, uint256 timestamp);
+    event SetInfo(string info, address setter, uint256 timestamp);
+    event ChangeOwnership(address caller, address newOwner, uint256 timestamp);
+
+    //------------------------
+    //  MODIFIERS
+    //------------------------
+    modifier ownerOnly() {
+        require(
+            msg.sender == state.owner,
+            "ACfManager: Only owner can call this function."
+        );
+        _;
+    }
+
+    modifier active() {
+        require(
+            !state.canceled,
+            "ACfManager: The campaign has been canceled."
+        );
+        _;
+    }
+
+    modifier finalized() {
+        require(
+            state.finalized,
+            "ACfManager: The campaign is not finalized."
+        );
+        _;
+    }
+
+    modifier notFinalized() {
+        require(
+            !state.finalized,
+            "ACfManager: The campaign is finalized."
+        );
+        _;
+    }
+
+    modifier isWhitelisted(address investor) {
+        require(
+            !state.whitelistRequired || (state.whitelistRequired && _walletApproved(investor)),
+            "ACfManager: Wallet not whitelisted."
+        );
+        _;
+    }
+
+    //------------------------
+    // STATE CHANGE FUNCTIONS
+    //------------------------
+    function invest(uint256 amount) external {
+        _invest(msg.sender, msg.sender, amount);
+    }
+
+    function investForBeneficiary(address spender, address beneficiary, uint256 amount) external {
+        if (spender != beneficiary) {
+            require(
+                spender == msg.sender,
+                "ACfManager: Only spender can decide to book the investment on somone else."
+            );
+        }
+        _invest(spender, beneficiary, amount);
+    }
+
+    function cancelInvestment() external notFinalized {
+        uint256 tokens = claims[msg.sender];
+        uint256 tokenValue = investments[msg.sender];
+        require(
+            tokens > 0 && tokenValue > 0,
+            "ACfManager: No tokens owned."
+        );
+        state.totalInvestorsCount -= 1;
+        claims[msg.sender] = 0;
+        investments[msg.sender] = 0;
+        tokenAmounts[msg.sender] = 0;
+        state.totalClaimableTokens -= tokens;
+        state.totalTokensSold -= tokens;
+        state.totalFundsRaised -= tokenValue;
+        _stablecoin().safeTransfer(msg.sender, tokenValue);
+        emit CancelInvestment(msg.sender, state.asset, tokens, tokenValue, block.timestamp);
+    }
+
+    function cancelInvestmentFor(address investor) external {
+        require(
+            state.canceled,
+            "ACfManager: Can only cancel for somoneone if the campaign has been canceled."
+        );
+        _cancel_investment(investor);
+    }
+
+    function finalize() external ownerOnly active notFinalized {
+        IERC20 stablecoin = _stablecoin();
+        uint256 fundsRaised = stablecoin.balanceOf(address(this));
+        require(
+            fundsRaised >= state.softCap,
+            "ACfManager: Can only finalize campaign if the minimum funding goal has been reached."
+        );
+        state.finalized = true;
+        IERC20 assetERC20 = _assetERC20();
+        uint256 tokensSold = state.totalTokensSold;
+        uint256 tokensRefund = assetERC20.balanceOf(address(this)) - tokensSold;
+        IAssetCommon(state.asset).finalizeSale();
+        if (fundsRaised > 0) {
+            (address treasury, uint256 fee) = _calculateFee();
+            if (fee > 0 && treasury != address(0)) {
+                stablecoin.safeTransfer(treasury, fee);
+                stablecoin.safeTransfer(msg.sender, fundsRaised - fee);
+            } else {
+                stablecoin.safeTransfer(msg.sender, fundsRaised);
+            }
+        }
+        if (tokensRefund > 0) { assetERC20.safeTransfer(msg.sender, tokensRefund); }
+        emit Finalize(msg.sender, state.asset, fundsRaised, tokensSold, tokensRefund, block.timestamp);
+    }
+
+    function cancelCampaign() external ownerOnly active notFinalized {
+        state.canceled = true;
+        uint256 tokenBalance = _assetERC20().balanceOf(address(this));
+        if(tokenBalance > 0) { _assetERC20().safeTransfer(msg.sender, tokenBalance); }
+        emit CancelCampaign(msg.sender, state.asset, tokenBalance, block.timestamp);
+    }
+    function flavor() external view override returns (string memory) { return state.flavor; }
+
+    function version() external view override returns (string memory) { return state.version; }
+
+    function commonState() external view override returns (Structs.CampaignCommonState memory) {
+        return Structs.CampaignCommonState(
+            state.flavor,
+            state.version,
+            state.contractAddress,
+            state.owner,
+            state.info,
+            state.asset,
+            state.stablecoin,
+            state.softCap,
+            state.finalized,
+            state.canceled,
+            state.tokenPrice,
+            state.totalFundsRaised,
+            state.totalTokensSold
+        );
+    }
+    function investmentAmount(address investor) external view override returns (uint256) { return investments[investor]; }
+    function tokenAmount(address investor) external view override returns (uint256) { return tokenAmounts[investor]; }
+    function claimedAmount(address investor) external view override returns (uint256) { return claims[investor]; }
+
+    function setInfo(string memory info) external override ownerOnly {
+        infoHistory.push(Structs.InfoEntry(
+                info,
+                block.timestamp
+            ));
+        state.info = info;
+        emit SetInfo(info, msg.sender, block.timestamp);
+    }
+
+    function getInfoHistoryInternal() internal view returns (Structs.InfoEntry[] memory) {
+        return infoHistory;
+    }
+
+    function changeOwnershipInternal(address newOwner) internal ownerOnly {
+        state.owner = newOwner;
+        emit ChangeOwnership(msg.sender, newOwner, block.timestamp);
+    }
+
+    //------------------------
+    //  HELPERS
+    //------------------------
+    function _invest(address spender, address investor, uint256 amount) internal active notFinalized isWhitelisted(investor) {
+        require(amount > 0, "ACfManager: Investment amount has to be greater than 0.");
+        uint256 tokenBalance = _assetERC20().balanceOf(address(this));
+        require(_token_value(tokenBalance) >= state.softCap, "CfManagerSoftcapVesting: not enough tokens for sale to reach the softcap.");
+        uint256 floatingTokens = tokenBalance - state.totalClaimableTokens;
+        require(floatingTokens > 0, "ACfManager: No more tokens available for sale.");
+
+        uint256 tokens = amount
+        * _asset_price_precision()
+        * _asset_decimals_precision()
+        / state.tokenPrice
+        / _stablecoin_decimals_precision();
+        uint256 tokenValue = _token_value(tokens);
+        require(tokens > 0 && tokenValue > 0, "ACfManager: Investment amount too low.");
+        require(floatingTokens >= tokens, "ACfManager: Not enough tokens left for this investment amount.");
+        uint256 totalInvestmentValue = _token_value(tokens + claims[investor]);
+        require(
+            totalInvestmentValue >= _adjusted_min_investment(floatingTokens),
+            "ACfManager: Investment amount too low."
+        );
+        require(
+            totalInvestmentValue <= state.maxInvestment,
+            "ACfManager: Investment amount too high."
+        );
+
+        _stablecoin().safeTransferFrom(spender, address(this), tokenValue);
+
+        if (claims[investor] == 0) {
+            state.totalInvestorsCount += 1;
+        }
+        claims[investor] += tokens;
+        investments[investor] += tokenValue;
+        tokenAmounts[investor] += tokens;
+        state.totalClaimableTokens += tokens;
+        state.totalTokensSold += tokens;
+        state.totalFundsRaised += tokenValue;
+        emit Invest(investor, state.asset, tokens, tokenValue, block.timestamp);
+    }
+
+    function _cancel_investment(address investor) internal {
+        uint256 tokens = claims[investor];
+        uint256 tokenValue = investments[investor];
+        require(
+            tokens > 0 && tokenValue > 0,
+            "ACfManager: No tokens owned."
+        );
+        state.totalInvestorsCount -= 1;
+        claims[investor] = 0;
+        investments[investor] = 0;
+        tokenAmounts[investor] = 0;
+        state.totalClaimableTokens -= tokens;
+        state.totalTokensSold -= tokens;
+        state.totalFundsRaised -= tokenValue;
+        _stablecoin().safeTransfer(investor, tokenValue);
+        emit CancelInvestment(investor, state.asset, tokens, tokenValue, block.timestamp);
+    }
+
+    function _calculateFee() internal returns (address, uint256) {
+        (bool success, bytes memory result) = state.feeManager.call(
+            abi.encodeWithSignature("calculateFee(address)", address(this))
+        );
+        if (success) {
+            return abi.decode(result, (address, uint256));
+        } else { return (address(0), 0); }
+    }
+
+    function _stablecoin() internal view returns (IERC20) {
+        return IERC20(state.stablecoin);
+    }
+
+    function _assetERC20() internal view returns (IERC20) {
+        return IERC20(state.asset);
+    }
+
+    function _asset_decimals_precision() internal view returns (uint256) {
+        return 10 ** IToken(state.asset).decimals();
+    }
+
+    function _asset_price_precision() internal view returns (uint256) {
+        return IAssetCommon(state.asset).priceDecimalsPrecision();
+    }
+
+    function _stablecoin_decimals_precision() internal view returns (uint256) {
+        return 10 ** IToken(state.stablecoin).decimals();
+    }
+
+    function _token_value(uint256 tokens) internal view returns (uint256) {
+        return tokens
+        * state.tokenPrice
+        * _stablecoin_decimals_precision()
+        / _asset_price_precision()
+        / _asset_decimals_precision();
+    }
+
+    function _walletApproved(address wallet) internal view returns (bool) {
+        return IIssuerCommon(state.issuer).isWalletApproved(wallet);
+    }
+
+    function _adjusted_min_investment(uint256 remainingTokens) internal view returns (uint256) {
+        uint256 remainingTokensValue = _token_value(remainingTokens);
+        return (remainingTokensValue < state.minInvestment) ? remainingTokensValue : state.minInvestment;
+    }
+
+    function _token_value_to_soft_cap() private view returns (uint256) {
+        return
+        _token_value(
+            _token_amount_for_investment(state.softCap - state.totalFundsRaised)
+        );
+    }
+
+    function _token_amount_for_investment(uint256 investment) private view returns (uint256) {
+        return investment
+        * _asset_price_precision()
+        * _asset_decimals_precision()
+        / state.tokenPrice
+        / _stablecoin_decimals_precision();
+    }
+}

--- a/contracts/managers/IACfManager.sol
+++ b/contracts/managers/IACfManager.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../shared/ICampaignCommon.sol";
+
+interface IACfManager is ICampaignCommon {
+    function getInfoHistory() external view returns (Structs.InfoEntry[] memory);
+    function changeOwnership(address newOwner) external;
+}

--- a/contracts/managers/crowdfunding-softcap-vesting/CfManagerSoftcapVesting.sol
+++ b/contracts/managers/crowdfunding-softcap-vesting/CfManagerSoftcapVesting.sol
@@ -180,6 +180,12 @@ contract CfManagerSoftcapVesting is ICfManagerSoftcapVesting {
     }
 
     function investForBeneficiary(address spender, address beneficiary, uint256 amount) external {
+        if (spender != beneficiary) { 
+            require(
+                spender == msg.sender,
+                "CfManagerSoftcap: Only spender can decide to book the investment on somone else."
+            );
+        }
         _invest(spender, beneficiary, amount);
     }
 

--- a/contracts/managers/crowdfunding-softcap-vesting/CfManagerSoftcapVesting.sol
+++ b/contracts/managers/crowdfunding-softcap-vesting/CfManagerSoftcapVesting.sol
@@ -161,10 +161,6 @@ contract CfManagerSoftcapVesting is ICfManagerSoftcapVesting, ACfManager {
     //------------------------
     //  ICfManagerSoftcap IMPL
     //------------------------
-    function getInfoHistory() external view override returns (Structs.InfoEntry[] memory) {
-        return getInfoHistoryInternal();
-    }
-
     function getState() external view override returns (Structs.CfManagerSoftcapVestingState memory) {
         return Structs.CfManagerSoftcapVestingState(
             state.flavor,
@@ -195,10 +191,6 @@ contract CfManagerSoftcapVesting is ICfManagerSoftcapVesting, ACfManager {
             vestingState.revoked,
             state.feeManager
         );
-    }
-
-    function changeOwnership(address newOwner) external override ownerOnly {
-        changeOwnershipInternal(newOwner);
     }
 
     //------------------------

--- a/contracts/managers/crowdfunding-softcap-vesting/CfManagerSoftcapVesting.sol
+++ b/contracts/managers/crowdfunding-softcap-vesting/CfManagerSoftcapVesting.sol
@@ -8,55 +8,28 @@ import "../../tokens/erc20/IToken.sol";
 import "../../shared/IAssetCommon.sol";
 import "../../shared/IIssuerCommon.sol";
 import "../../shared/Structs.sol";
+import "../ACfManager.sol";
 
-contract CfManagerSoftcapVesting is ICfManagerSoftcapVesting {
+contract CfManagerSoftcapVesting is ICfManagerSoftcapVesting, ACfManager {
     using SafeERC20 for IERC20;
 
     //------------------------
     //  STATE
     //------------------------
-    Structs.CfManagerSoftcapVestingState private state;
-    Structs.InfoEntry[] private infoHistory;
-    mapping (address => uint256) private claims;
-    mapping (address => uint256) private investments;
-    mapping (address => uint256) private tokenAmounts;
+    struct VestingState {
+        bool vestingStarted;
+        uint256 start;
+        uint256 cliff;
+        uint256 duration;
+        bool revocable;
+        bool revoked;
+    }
+    VestingState private vestingState;
     mapping (address => uint256) private released;
 
     //------------------------
     //  EVENTS
     //------------------------
-    event Invest(
-        address indexed investor,
-        address asset,
-        uint256 tokenAmount,
-        uint256 tokenValue,
-        uint256 timestamp
-    );
-    event Claim(
-        address indexed investor,
-        address asset,
-        uint256 tokenAmount,
-        uint256 tokenValue,
-        uint256 timestamp
-    );
-    event CancelInvestment(
-        address indexed investor,
-        address asset,
-        uint256 tokenAmount,
-        uint256 tokenValue,
-        uint256 timestamp
-    );
-    event Finalize(
-        address indexed owner,
-        address asset,
-        uint256 fundsRaised,
-        uint256 tokensSold,
-        uint256 tokensRefund,
-        uint256 timestamp
-    );
-    event CancelCampaign(address indexed owner, address asset, uint256 tokensReturned, uint256 timestamp);
-    event SetInfo(string info, address setter, uint256 timestamp);
-    event ChangeOwnership(address caller, address newOwner, uint256 timestamp);
     event StartVesting(
         address indexed owner,
         address asset,
@@ -95,7 +68,7 @@ contract CfManagerSoftcapVesting is ICfManagerSoftcapVesting {
         require(maxInvestment > 0, "CfManagerSoftcapVesting: Max investment has to be bigger than 0.");
         IIssuerCommon issuer = IIssuerCommon(IAssetCommon(asset).commonState().issuer);
         uint256 softCapNormalized = (softCap / tokenPrice) * tokenPrice;
-        state = Structs.CfManagerSoftcapVestingState(
+        state = Structs.CfManagerState(
             contractFlavor,
             contractVersion,
             address(this),
@@ -112,9 +85,9 @@ contract CfManagerSoftcapVesting is ICfManagerSoftcapVesting {
             false,
             0, 0, 0, 0, 0,
             info,
-            false, 0, 0, 0, true, false,
             feeManager
         );
+        vestingState = VestingState(false, 0, 0, 0, true, false);
         require(
             _token_value(IToken(asset).totalSupply()) >= softCapNormalized,
             "CfManagerSoftcapVesting: Invalid soft cap."
@@ -124,49 +97,9 @@ contract CfManagerSoftcapVesting is ICfManagerSoftcapVesting {
     //------------------------
     //  MODIFIERS
     //------------------------
-    modifier ownerOnly() {
-        require(
-            msg.sender == state.owner,
-            "CfManagerSoftcapVesting: Only owner can call this function."
-        );
-        _;
-    }
-
-    modifier active() {
-        require(
-            !state.canceled,
-            "CfManagerSoftcapVesting: The campaign has been canceled."
-        );
-        _;
-    }
-
-    modifier finalized() {
-        require(
-            state.finalized,
-            "CfManagerSoftcapVesting: The campaign is not finalized."
-        );
-        _;
-    }
-
-    modifier notFinalized() {
-        require(
-            !state.finalized,
-            "CfManagerSoftcapVesting: The campaign is finalized."
-        );
-        _;
-    }
-
-    modifier isWhitelisted(address investor) {
-        require(
-            !state.whitelistRequired || (state.whitelistRequired && _walletApproved(investor)),
-            "CfManagerSoftcapVesting: Wallet not whitelisted."
-        );
-        _;
-    }
-
     modifier vestingStarted() {
         require(
-            state.vestingStarted,
+            vestingState.vestingStarted,
             "CfManagerSoftcapVesting: Vesting not started"
         );
         _;
@@ -175,32 +108,6 @@ contract CfManagerSoftcapVesting is ICfManagerSoftcapVesting {
     //------------------------
     // STATE CHANGE FUNCTIONS
     //------------------------
-    function invest(uint256 amount) external {
-        _invest(msg.sender, msg.sender, amount);
-    }
-
-    function investForBeneficiary(address spender, address beneficiary, uint256 amount) external {
-        if (spender != beneficiary) { 
-            require(
-                spender == msg.sender,
-                "CfManagerSoftcap: Only spender can decide to book the investment on somone else."
-            );
-        }
-        _invest(spender, beneficiary, amount);
-    }
-
-    function cancelInvestment() external notFinalized {
-        _cancel_investment(msg.sender);
-    }
-
-    function cancelInvestmentFor(address investor) external {
-        require(
-            state.canceled,
-            "CfManagerSoftcapVesting: Can only cancel for somoneone if the campaign has been canceled."
-        );
-        _cancel_investment(investor);
-    }
-
     function claim(address investor) external finalized vestingStarted {
         uint256 unreleased = _releasableAmount(investor);
         uint256 unreleasedValue = _token_value(unreleased);
@@ -218,14 +125,14 @@ contract CfManagerSoftcapVesting is ICfManagerSoftcapVesting {
         uint256 cliffDuration,
         uint256 duration
     ) external ownerOnly finalized {
-        require(!state.vestingStarted, "CfManagerSoftcapVesting: Vesting already started.");
+        require(!vestingState.vestingStarted, "CfManagerSoftcapVesting: Vesting already started.");
         require(cliffDuration <= duration, "CfManagerSoftcapVesting: cliffDuration <= duration");
         require(duration > 0, "CfManagerSoftcapVesting: duration > 0");
         require(start + duration > block.timestamp, "CfManagerSoftcapVesting: start + duration > block.timestamp");
-        state.vestingStarted = true;
-        state.start = start;
-        state.cliff = start + cliffDuration;
-        state.duration = duration;
+        vestingState.vestingStarted = true;
+        vestingState.start = start;
+        vestingState.cliff = start + cliffDuration;
+        vestingState.duration = duration;
         emit StartVesting(
             msg.sender,
             state.asset,
@@ -237,178 +144,74 @@ contract CfManagerSoftcapVesting is ICfManagerSoftcapVesting {
     }
 
     function revoke() public ownerOnly finalized vestingStarted {
-        require(state.revocable, "CfManagerSoftcapVesting: Campaign vesting configuration not revocable.");
-        require(!state.revoked, "CfManagerSoftcapVesting: Campaign vesting already revoked.");
+        require(vestingState.revocable, "CfManagerSoftcapVesting: Campaign vesting configuration not revocable.");
+        require(!vestingState.revoked, "CfManagerSoftcapVesting: Campaign vesting already revoked.");
 
         uint256 balance = state.totalClaimableTokens;
         uint256 unreleased = _totalReleasableAmount();
         uint256 refund = balance - unreleased;
 
-        state.revoked = true;
+        vestingState.revoked = true;
 
         _assetERC20().safeTransfer(msg.sender, refund);
 
         emit Revoke(msg.sender, state.asset, refund, block.timestamp);
     }
 
-    function finalize() external ownerOnly active notFinalized {
-        IERC20 stablecoin = _stablecoin();
-        uint256 fundsRaised = stablecoin.balanceOf(address(this));
-        require(
-            fundsRaised >= state.softCap || _token_value_to_soft_cap() == 0,
-            "CfManagerSoftcapVesting: Can only finalize campaign if the minimum funding goal has been reached."
-        );
-        state.finalized = true;  
-        IERC20 assetERC20 = _assetERC20();
-        uint256 tokensSold = state.totalTokensSold;
-        uint256 tokensRefund = assetERC20.balanceOf(address(this)) - tokensSold;
-        IAssetCommon(state.asset).finalizeSale();
-        if (fundsRaised > 0) {
-            (address treasury, uint256 fee) = _calculateFee();
-            if (fee > 0 && treasury != address(0)) {
-                stablecoin.safeTransfer(treasury, fee);
-                stablecoin.safeTransfer(msg.sender, fundsRaised - fee);
-            } else {
-                stablecoin.safeTransfer(msg.sender, fundsRaised);
-            }
-        }
-        if (tokensRefund > 0) { assetERC20.safeTransfer(msg.sender, tokensRefund); }
-        emit Finalize(msg.sender, state.asset, fundsRaised, tokensSold, tokensRefund, block.timestamp);
-    }
-
-    function cancelCampaign() external ownerOnly active notFinalized {
-        state.canceled = true;
-        uint256 tokenBalance = _assetERC20().balanceOf(address(this));
-        if(tokenBalance > 0) { _assetERC20().safeTransfer(msg.sender, tokenBalance); }
-        emit CancelCampaign(msg.sender, state.asset, tokenBalance, block.timestamp);
-    }
-
     //------------------------
     //  ICfManagerSoftcap IMPL
     //------------------------
-    function flavor() external view override returns (string memory) { return state.flavor; }
+    function getInfoHistory() external view override returns (Structs.InfoEntry[] memory) {
+        return getInfoHistoryInternal();
+    }
 
-    function version() external view override returns (string memory) { return state.version; }
-    
-    function commonState() external view override returns (Structs.CampaignCommonState memory) {
-        return Structs.CampaignCommonState(
+    function getState() external view override returns (Structs.CfManagerSoftcapVestingState memory) {
+        return Structs.CfManagerSoftcapVestingState(
             state.flavor,
             state.version,
             state.contractAddress,
             state.owner,
-            state.info,
             state.asset,
+            state.issuer,
             state.stablecoin,
+            state.tokenPrice,
             state.softCap,
+            state.minInvestment,
+            state.maxInvestment,
+            state.whitelistRequired,
             state.finalized,
             state.canceled,
-            state.tokenPrice,
+            state.totalClaimableTokens,
+            state.totalInvestorsCount,
             state.totalFundsRaised,
-            state.totalTokensSold
+            state.totalTokensSold,
+            _assetERC20().balanceOf(address(this)),
+            state.info,
+            vestingState.vestingStarted,
+            vestingState.start,
+            vestingState.cliff,
+            vestingState.duration,
+            vestingState.revocable,
+            vestingState.revoked,
+            state.feeManager
         );
     }
 
-    function investmentAmount(address investor) external view override returns (uint256) { return investments[investor]; }
-    function tokenAmount(address investor) external view override returns (uint256) { return tokenAmounts[investor]; }
-    function claimedAmount(address investor) external view override returns (uint256) { return claims[investor]; }
-
-    function setInfo(string memory info) external override ownerOnly {
-        infoHistory.push(Structs.InfoEntry(
-            info,
-            block.timestamp
-        ));
-        state.info = info;
-        emit SetInfo(info, msg.sender, block.timestamp);
-    }
-
-    function getInfoHistory() external view override returns (Structs.InfoEntry[] memory) {
-        return infoHistory;
-    }
-
-    function getState() external view override returns (Structs.CfManagerSoftcapVestingState memory) {
-        Structs.CfManagerSoftcapVestingState memory stateWithBalance = state; 
-        stateWithBalance.totalTokensBalance = _assetERC20().balanceOf(address(this));
-        return stateWithBalance;
-    }
-
     function changeOwnership(address newOwner) external override ownerOnly {
-        state.owner = newOwner;
-        emit ChangeOwnership(msg.sender, newOwner, block.timestamp);
+        changeOwnershipInternal(newOwner);
     }
 
     //------------------------
     //  HELPERS
     //------------------------
-    function _invest(address spender, address investor, uint256 amount) private active notFinalized isWhitelisted(investor) {
-        require(amount > 0, "CfManagerSoftcapVesting: Investment amount has to be greater than 0.");
-        uint256 tokenBalance = _assetERC20().balanceOf(address(this));
-        require(_token_value(tokenBalance) >= state.softCap, "CfManagerSoftcapVesting: not enough tokens for sale to reach the softcap.");
-        uint256 floatingTokens = tokenBalance - state.totalClaimableTokens;
-        require(floatingTokens > 0, "CfManagerSoftcapVesting: No more tokens available for sale.");
-
-        uint256 tokens = _token_amount_for_investment(amount);
-        uint256 tokenValue = _token_value(tokens);
-        require(tokens > 0 && tokenValue > 0, "CfManagerSoftcapVesting: Investment amount too low.");
-        require(floatingTokens >= tokens, "CfManagerSoftcapVesting: Not enough tokens left for this investment amount.");        
-        uint256 totalInvestmentValue = _token_value(tokens + claims[investor]);
-        require(
-            totalInvestmentValue >= _adjusted_min_investment(floatingTokens),
-            "CfManagerSoftcapVesting: Investment amount too low."
-        );
-        require(
-            totalInvestmentValue <= state.maxInvestment,
-            "CfManagerSoftcapVesting: Investment amount too high."
-        );
-
-        _stablecoin().safeTransferFrom(spender, address(this), tokenValue);
-
-        if (claims[investor] == 0) {
-            state.totalInvestorsCount += 1;
-        }
-        claims[investor] += tokens;
-        investments[investor] += tokenValue;
-        tokenAmounts[investor] += tokens;
-        state.totalClaimableTokens += tokens;
-        state.totalTokensSold += tokens;
-        state.totalFundsRaised += tokenValue;
-        emit Invest(investor, state.asset, tokens, tokenValue, block.timestamp);
-    }
-
-    function _cancel_investment(address investor) private {
-        uint256 tokens = claims[investor];
-        uint256 tokenValue = investments[investor];
-        require(
-            tokens > 0 && tokenValue > 0,
-            "CfManagerSoftcap: No tokens owned."
-        );
-        state.totalInvestorsCount -= 1;
-        claims[investor] = 0;
-        investments[investor] = 0;
-        tokenAmounts[investor] = 0;
-        state.totalClaimableTokens -= tokens;
-        state.totalTokensSold -= tokens;
-        state.totalFundsRaised -= tokenValue;
-        _stablecoin().safeTransfer(investor, tokenValue);
-        emit CancelInvestment(investor, state.asset, tokens, tokenValue, block.timestamp);
-    }
-
-    function _calculateFee() private returns (address, uint256) {
-        (bool success, bytes memory result) = state.feeManager.call(
-            abi.encodeWithSignature("calculateFee(address)", address(this))
-        );
-        if (success) {
-            return abi.decode(result, (address, uint256));
-        } else { return (address(0), 0); }
-    }
-
     function _totalReleasableAmount() private view returns (uint256) {
         uint256 vestedAmount;
-        if (block.timestamp < state.cliff) {
+        if (block.timestamp < vestingState.cliff) {
             vestedAmount = 0;
-        } else if (block.timestamp >= (state.start + state.duration) || state.revoked) {
+        } else if (block.timestamp >= (vestingState.start + vestingState.duration) || vestingState.revoked) {
             vestedAmount = state.totalTokensSold;
         } else {
-            vestedAmount = state.totalTokensSold * (block.timestamp - state.start) / state.duration;
+            vestedAmount = state.totalTokensSold * (block.timestamp - vestingState.start) / vestingState.duration;
         }
         return vestedAmount - (state.totalTokensSold - state.totalClaimableTokens);
     }
@@ -418,65 +221,13 @@ contract CfManagerSoftcapVesting is ICfManagerSoftcapVesting {
     }
 
     function _vestedAmount(address investor) private view returns (uint256) {
-        if (block.timestamp < state.cliff) {
+        if (block.timestamp < vestingState.cliff) {
             return 0;
-        } else if (block.timestamp >= (state.start + state.duration) || state.revoked) {
+        } else if (block.timestamp >= (vestingState.start + vestingState.duration) || vestingState.revoked) {
             return tokenAmounts[investor];
         } else {
-            return tokenAmounts[investor] * (block.timestamp - state.start) / state.duration;
+            return tokenAmounts[investor] * (block.timestamp - vestingState.start) / vestingState.duration;
         }
-    }
-
-    function _stablecoin() private view returns (IERC20) {
-        return IERC20(state.stablecoin);
-    }
-
-    function _assetERC20() private view returns (IERC20) {
-        return IERC20(state.asset);
-    }
-
-    function _asset_decimals_precision() private view returns (uint256) {
-        return 10 ** IToken(state.asset).decimals();
-    }
-
-    function _asset_price_precision() private view returns (uint256) {
-        return IAssetCommon(state.asset).priceDecimalsPrecision();
-    }
-
-    function _stablecoin_decimals_precision() private view returns (uint256) {
-        return 10 ** IToken(state.stablecoin).decimals();
-    }
-
-    function _token_value_to_soft_cap() private view returns (uint256) {
-        return 
-            _token_value(
-                _token_amount_for_investment(state.softCap - state.totalFundsRaised)
-            );
-    }
-
-    function _token_amount_for_investment(uint256 investment) private view returns (uint256) {
-        return investment
-                    * _asset_price_precision()
-                    * _asset_decimals_precision()
-                    / state.tokenPrice
-                    / _stablecoin_decimals_precision();
-    }
-
-    function _token_value(uint256 tokens) private view returns (uint256) {
-        return tokens
-                    * state.tokenPrice
-                    * _stablecoin_decimals_precision()
-                    / _asset_price_precision()
-                    / _asset_decimals_precision();
-    }
-
-    function _walletApproved(address wallet) private view returns (bool) {
-        return IIssuerCommon(state.issuer).isWalletApproved(wallet);
-    }
-
-    function _adjusted_min_investment(uint256 remainingTokens) private view returns (uint256) {
-        uint256 remainingTokensValue = _token_value(remainingTokens);
-        return (remainingTokensValue < state.minInvestment) ? remainingTokensValue : state.minInvestment;
     }
 
 }

--- a/contracts/managers/crowdfunding-softcap-vesting/CfManagerSoftcapVestingFactory.sol
+++ b/contracts/managers/crowdfunding-softcap-vesting/CfManagerSoftcapVestingFactory.sol
@@ -10,7 +10,7 @@ import "../../registry/INameRegistry.sol";
 contract CfManagerSoftcapVestingFactory is ICfManagerSoftcapVestingFactory {
     
     string constant public FLAVOR = "CfManagerSoftcapVestingV1";
-    string constant public VERSION = "1.0.22";
+    string constant public VERSION = "1.0.23";
     
     address[] public instances;
     mapping (address => address[]) instancesPerIssuer;

--- a/contracts/managers/crowdfunding-softcap-vesting/ICfManagerSoftcapVesting.sol
+++ b/contracts/managers/crowdfunding-softcap-vesting/ICfManagerSoftcapVesting.sol
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "../../shared/ICampaignCommon.sol";
+import "../IACfManager.sol";
 import "../../shared/Structs.sol";
 
-interface ICfManagerSoftcapVesting is ICampaignCommon {
-    function getInfoHistory() external view returns (Structs.InfoEntry[] memory);
+interface ICfManagerSoftcapVesting is IACfManager {
     function getState() external view returns (Structs.CfManagerSoftcapVestingState memory);
-    function changeOwnership(address newOwner) external;
 }

--- a/contracts/managers/crowdfunding-softcap/CfManagerSoftcap.sol
+++ b/contracts/managers/crowdfunding-softcap/CfManagerSoftcap.sol
@@ -156,6 +156,12 @@ contract CfManagerSoftcap is ICfManagerSoftcap {
     }
 
     function investForBeneficiary(address spender, address beneficiary, uint256 amount) external {
+        if (spender != beneficiary) { 
+            require(
+                spender == msg.sender,
+                "CfManagerSoftcap: Only spender can decide to book the investment on somone else."
+            );
+        }
         _invest(spender, beneficiary, amount);
     }
 

--- a/contracts/managers/crowdfunding-softcap/CfManagerSoftcap.sol
+++ b/contracts/managers/crowdfunding-softcap/CfManagerSoftcap.sol
@@ -112,13 +112,4 @@ contract CfManagerSoftcap is ICfManagerSoftcap, ACfManager {
             state.feeManager
         );
     }
-
-    function getInfoHistory() external view override returns (Structs.InfoEntry[] memory) {
-        return getInfoHistoryInternal();
-    }
-
-    function changeOwnership(address newOwner) external override {
-        changeOwnershipInternal(newOwner);
-    }
-
 }

--- a/contracts/managers/crowdfunding-softcap/CfManagerSoftcap.sol
+++ b/contracts/managers/crowdfunding-softcap/CfManagerSoftcap.sol
@@ -8,54 +8,15 @@ import "../../tokens/erc20/IToken.sol";
 import "../../shared/IAssetCommon.sol";
 import "../../shared/IIssuerCommon.sol";
 import "../../shared/Structs.sol";
+import "../ACfManager.sol";
 
-contract CfManagerSoftcap is ICfManagerSoftcap {
+contract CfManagerSoftcap is ICfManagerSoftcap, ACfManager {
     using SafeERC20 for IERC20;
 
     //------------------------
     //  STATE
     //------------------------
-    Structs.CfManagerSoftcapState private state;
-    Structs.InfoEntry[] private infoHistory;
-    mapping (address => uint256) private claims;
-    mapping (address => uint256) private investments;
-    mapping (address => uint256) private tokenAmounts;
-
-    //------------------------
-    //  EVENTS
-    //------------------------
-    event Invest(
-        address indexed investor,
-        address asset,
-        uint256 tokenAmount,
-        uint256 tokenValue,
-        uint256 timestamp
-    );
-    event Claim(
-        address indexed investor,
-        address asset,
-        uint256 tokenAmount,
-        uint256 tokenValue,
-        uint256 timestamp
-    );
-    event CancelInvestment(
-        address indexed investor,
-        address asset,
-        uint256 tokenAmount,
-        uint256 tokenValue,
-        uint256 timestamp
-    );
-    event Finalize(
-        address indexed owner,
-        address asset,
-        uint256 fundsRaised,
-        uint256 tokensSold,
-        uint256 tokensRefund,
-        uint256 timestamp
-    );
-    event CancelCampaign(address indexed owner, address asset, uint256 tokensReturned, uint256 timestamp);
-    event SetInfo(string info, address setter, uint256 timestamp);
-    event ChangeOwnership(address caller, address newOwner, uint256 timestamp);
+    uint256 private totalClaimsCount = 0;
 
     //------------------------
     //  CONSTRUCTOR
@@ -80,7 +41,7 @@ contract CfManagerSoftcap is ICfManagerSoftcap {
         require(maxInvestment > 0, "CfManagerSoftcap: Max investment has to be bigger than 0.");
         uint256 softCapNormalized = (softCap / tokenPrice) * tokenPrice;
         IIssuerCommon issuer = IIssuerCommon(IAssetCommon(asset).commonState().issuer);
-        state = Structs.CfManagerSoftcapState(
+        state = Structs.CfManagerState(
             contractFlavor,
             contractVersion,
             address(this),
@@ -95,7 +56,7 @@ contract CfManagerSoftcap is ICfManagerSoftcap {
             whitelistRequired,
             false,
             false,
-            0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
             info,
             feeManager
         );
@@ -106,77 +67,8 @@ contract CfManagerSoftcap is ICfManagerSoftcap {
     }
 
     //------------------------
-    //  MODIFIERS
-    //------------------------
-    modifier ownerOnly() {
-        require(
-            msg.sender == state.owner,
-            "CfManagerSoftcap: Only owner can call this function."
-        );
-        _;
-    }
-
-    modifier active() {
-        require(
-            !state.canceled,
-            "CfManagerSoftcap: The campaign has been canceled."
-        );
-        _;
-    }
-
-    modifier finalized() {
-        require(
-            state.finalized,
-            "CfManagerSoftcap: The campaign is not finalized."
-        );
-        _;
-    }
-
-    modifier notFinalized() {
-        require(
-            !state.finalized,
-            "CfManagerSoftcap: The campaign is finalized."
-        );
-        _;
-    }
-
-    modifier isWhitelisted(address investor) {
-        require(
-            !state.whitelistRequired || (state.whitelistRequired && _walletApproved(investor)),
-            "CfManagerSoftcap: Wallet not whitelisted."
-        );
-        _;
-    }
-
-    //------------------------
     // STATE CHANGE FUNCTIONS
     //------------------------
-    function invest(uint256 amount) external {
-        _invest(msg.sender, msg.sender, amount);
-    }
-
-    function investForBeneficiary(address spender, address beneficiary, uint256 amount) external {
-        if (spender != beneficiary) { 
-            require(
-                spender == msg.sender,
-                "CfManagerSoftcap: Only spender can decide to book the investment on somone else."
-            );
-        }
-        _invest(spender, beneficiary, amount);
-    }
-
-    function cancelInvestment() external notFinalized {
-        _cancel_investment(msg.sender);
-    }
-
-    function cancelInvestmentFor(address investor) external {
-        require(
-            state.canceled,
-            "CfManagerSoftcapVesting: Can only cancel for somoneone if the campaign has been canceled."
-        );
-        _cancel_investment(investor);
-    }
-
     function claim(address investor) external finalized {
         uint256 claimableTokens = claims[investor];
         uint256 claimableTokensValue = investments[investor];
@@ -184,213 +76,49 @@ contract CfManagerSoftcap is ICfManagerSoftcap {
             claimableTokens > 0 && claimableTokensValue > 0,
             "CfManagerSoftcap: No tokens owned."
         );
-        state.totalClaimsCount += 1;
+        totalClaimsCount += 1;
         state.totalClaimableTokens -= claimableTokens;
         claims[investor] = 0;
         _assetERC20().safeTransfer(investor, claimableTokens);
         emit Claim(investor, state.asset, claimableTokens, claimableTokensValue, block.timestamp);
     }
 
-    function finalize() external ownerOnly active notFinalized {
-        IERC20 stablecoin = _stablecoin();
-        uint256 fundsRaised = stablecoin.balanceOf(address(this));
-        require(
-            fundsRaised >= state.softCap || _token_value_to_soft_cap() == 0,
-            "CfManagerSoftcap: Can only finalize campaign if the minimum funding goal has been reached."
-        );
-        state.finalized = true;  
-        IERC20 assetERC20 = _assetERC20();
-        uint256 tokensSold = state.totalTokensSold;
-        uint256 tokensRefund = assetERC20.balanceOf(address(this)) - tokensSold;
-        IAssetCommon(state.asset).finalizeSale();
-        if (fundsRaised > 0) {
-            (address treasury, uint256 fee) = _calculateFee();
-            if (fee > 0 && treasury != address(0)) {
-                stablecoin.safeTransfer(treasury, fee);
-                stablecoin.safeTransfer(msg.sender, fundsRaised - fee);
-            } else {
-                stablecoin.safeTransfer(msg.sender, fundsRaised);
-            }
-        }
-        if (tokensRefund > 0) { assetERC20.safeTransfer(msg.sender, tokensRefund); }
-        emit Finalize(msg.sender, state.asset, fundsRaised, tokensSold, tokensRefund, block.timestamp);
-    }
-
-    function cancelCampaign() external ownerOnly active notFinalized {
-        state.canceled = true;
-        uint256 tokenBalance = _assetERC20().balanceOf(address(this));
-        if(tokenBalance > 0) { _assetERC20().safeTransfer(msg.sender, tokenBalance); }
-        emit CancelCampaign(msg.sender, state.asset, tokenBalance, block.timestamp);
-    }
-
     //------------------------
     //  ICfManagerSoftcap IMPL
     //------------------------
-    function flavor() external view override returns (string memory) { return state.flavor; }
-
-    function version() external view override returns (string memory) { return state.version; }
-    
-    function commonState() external view override returns (Structs.CampaignCommonState memory) {
-        return Structs.CampaignCommonState(
+    function getState() external view override returns (Structs.CfManagerSoftcapState memory) {
+        return Structs.CfManagerSoftcapState(
             state.flavor,
             state.version,
             state.contractAddress,
             state.owner,
-            state.info,
             state.asset,
+            state.issuer,
             state.stablecoin,
+            state.tokenPrice,
             state.softCap,
+            state.minInvestment,
+            state.maxInvestment,
+            state.whitelistRequired,
             state.finalized,
             state.canceled,
-            state.tokenPrice,
+            state.totalClaimableTokens,
+            state.totalInvestorsCount,
+            totalClaimsCount,
             state.totalFundsRaised,
-            state.totalTokensSold
+            state.totalTokensSold,
+            _assetERC20().balanceOf(address(this)),
+            state.info,
+            state.feeManager
         );
-    }
-
-    function investmentAmount(address investor) external view override returns (uint256) { return investments[investor]; }
-    function tokenAmount(address investor) external view override returns (uint256) { return tokenAmounts[investor]; }
-    function claimedAmount(address investor) external view override returns (uint256) { return claims[investor]; }
-
-    function setInfo(string memory info) external override ownerOnly {
-        infoHistory.push(Structs.InfoEntry(
-            info,
-            block.timestamp
-        ));
-        state.info = info;
-        emit SetInfo(info, msg.sender, block.timestamp);
     }
 
     function getInfoHistory() external view override returns (Structs.InfoEntry[] memory) {
-        return infoHistory;
+        return getInfoHistoryInternal();
     }
 
-    function getState() external view override returns (Structs.CfManagerSoftcapState memory) {
-        Structs.CfManagerSoftcapState memory stateWithBalance = state; 
-        stateWithBalance.totalTokensBalance = _assetERC20().balanceOf(address(this));
-        return stateWithBalance;
-    }
-
-    function changeOwnership(address newOwner) external override ownerOnly {
-        state.owner = newOwner;
-        emit ChangeOwnership(msg.sender, newOwner, block.timestamp);
-    }
-
-    //------------------------
-    //  HELPERS
-    //------------------------
-    function _invest(address spender, address investor, uint256 amount) private active notFinalized isWhitelisted(investor) {
-        require(amount > 0, "CfManagerSoftcap: Investment amount has to be greater than 0.");
-        uint256 tokenBalance = _assetERC20().balanceOf(address(this));
-        require(_token_value(tokenBalance) >= state.softCap, "CfManagerSoftcap: not enough tokens for sale to reach the softcap.");
-        uint256 floatingTokens = tokenBalance - state.totalClaimableTokens;
-        require(floatingTokens > 0, "CfManagerSoftcap: No more tokens available for sale.");
-
-        uint256 tokens = _token_amount_for_investment(amount);
-        uint256 tokenValue = _token_value(tokens);
-        require(tokens > 0 && tokenValue > 0, "CfManagerSoftcap: Investment amount too low.");
-        require(floatingTokens >= tokens, "CfManagerSoftcap: Not enough tokens left for this investment amount.");        
-        uint256 totalInvestmentValue = _token_value(tokens + claims[investor]);
-        require(
-            totalInvestmentValue >= _adjusted_min_investment(floatingTokens),
-            "CfManagerSoftcap: Investment amount too low."
-        );
-        require(
-            totalInvestmentValue <= state.maxInvestment,
-            "CfManagerSoftcap: Investment amount too high."
-        );
-
-        _stablecoin().safeTransferFrom(spender, address(this), tokenValue);
-
-        if (claims[investor] == 0) {
-            state.totalInvestorsCount += 1;
-        }
-        claims[investor] += tokens;
-        investments[investor] += tokenValue;
-        tokenAmounts[investor] += tokens;
-        state.totalClaimableTokens += tokens;
-        state.totalTokensSold += tokens;
-        state.totalFundsRaised += tokenValue;
-        emit Invest(investor, state.asset, tokens, tokenValue, block.timestamp);
-    }
-
-    function _cancel_investment(address investor) private {
-        uint256 tokens = claims[investor];
-        uint256 tokenValue = investments[investor];
-        require(
-            tokens > 0 && tokenValue > 0,
-            "CfManagerSoftcap: No tokens owned."
-        );
-        state.totalInvestorsCount -= 1;
-        claims[investor] = 0;
-        investments[investor] = 0;
-        tokenAmounts[investor] = 0;
-        state.totalClaimableTokens -= tokens;
-        state.totalTokensSold -= tokens;
-        state.totalFundsRaised -= tokenValue;
-        _stablecoin().safeTransfer(investor, tokenValue);
-        emit CancelInvestment(investor, state.asset, tokens, tokenValue, block.timestamp);
-    }
-
-    function _calculateFee() private returns (address, uint256) {
-        (bool success, bytes memory result) = state.feeManager.call(
-            abi.encodeWithSignature("calculateFee(address)", address(this))
-        );
-        if (success) {
-            return abi.decode(result, (address, uint256));
-        } else { return (address(0), 0); }
-    }
-
-    function _stablecoin() private view returns (IERC20) {
-        return IERC20(state.stablecoin);
-    }
-
-    function _assetERC20() private view returns (IERC20) {
-        return IERC20(state.asset);
-    }
-
-    function _asset_decimals_precision() private view returns (uint256) {
-        return 10 ** IToken(state.asset).decimals();
-    }
-
-    function _asset_price_precision() private view returns (uint256) {
-        return IAssetCommon(state.asset).priceDecimalsPrecision();
-    }
-
-    function _stablecoin_decimals_precision() private view returns (uint256) {
-        return 10 ** IToken(state.stablecoin).decimals();
-    }
-
-    function _token_value_to_soft_cap() private view returns (uint256) {
-        return 
-            _token_value(
-                _token_amount_for_investment(state.softCap - state.totalFundsRaised)
-            );
-    }
-
-    function _token_amount_for_investment(uint256 investment) private view returns (uint256) {
-        return investment
-                    * _asset_price_precision()
-                    * _asset_decimals_precision()
-                    / state.tokenPrice
-                    / _stablecoin_decimals_precision();
-    }
-
-    function _token_value(uint256 tokens) private view returns (uint256) {
-        return tokens
-                    * state.tokenPrice
-                    * _stablecoin_decimals_precision()
-                    / _asset_price_precision()
-                    / _asset_decimals_precision();
-    }
-
-    function _walletApproved(address wallet) private view returns (bool) {
-        return IIssuerCommon(state.issuer).isWalletApproved(wallet);
-    }
-
-    function _adjusted_min_investment(uint256 remainingTokens) private view returns (uint256) {
-        uint256 remainingTokensValue = _token_value(remainingTokens);
-        return (remainingTokensValue < state.minInvestment) ? remainingTokensValue : state.minInvestment;
+    function changeOwnership(address newOwner) external override {
+        changeOwnershipInternal(newOwner);
     }
 
 }

--- a/contracts/managers/crowdfunding-softcap/CfManagerSoftcapFactory.sol
+++ b/contracts/managers/crowdfunding-softcap/CfManagerSoftcapFactory.sol
@@ -9,7 +9,7 @@ import "../../registry/INameRegistry.sol";
 contract CfManagerSoftcapFactory is ICfManagerSoftcapFactory {
     
     string constant public FLAVOR = "CfManagerSoftcapV1";
-    string constant public VERSION = "1.0.21";
+    string constant public VERSION = "1.0.23";
     
     address[] public instances;
     mapping (address => address[]) instancesPerIssuer;

--- a/contracts/managers/crowdfunding-softcap/ICfManagerSoftcap.sol
+++ b/contracts/managers/crowdfunding-softcap/ICfManagerSoftcap.sol
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "../../shared/ICampaignCommon.sol";
+import "../IACfManager.sol";
 import "../../shared/Structs.sol";
 
-interface ICfManagerSoftcap is ICampaignCommon {
-    function getInfoHistory() external view returns (Structs.InfoEntry[] memory);
+interface ICfManagerSoftcap is IACfManager {
     function getState() external view returns (Structs.CfManagerSoftcapState memory);
-    function changeOwnership(address newOwner) external;
 }

--- a/contracts/shared/Structs.sol
+++ b/contracts/shared/Structs.sol
@@ -263,6 +263,30 @@ contract Structs {
         string info;
     }
 
+    struct CfManagerState {
+        string flavor;
+        string version;
+        address contractAddress;
+        address owner;
+        address asset;
+        address issuer;
+        address stablecoin;
+        uint256 tokenPrice;
+        uint256 softCap;
+        uint256 minInvestment;
+        uint256 maxInvestment;
+        bool whitelistRequired;
+        bool finalized;
+        bool canceled;
+        uint256 totalClaimableTokens;
+        uint256 totalInvestorsCount;
+        uint256 totalFundsRaised;
+        uint256 totalTokensSold;
+        uint256 totalTokensBalance;
+        string info;
+        address feeManager;
+    }
+
     struct CfManagerSoftcapState {
         string flavor;
         string version;

--- a/contracts/tokens/stablecoin/USDC.sol
+++ b/contracts/tokens/stablecoin/USDC.sol
@@ -5,8 +5,15 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract USDC is ERC20 {
 
-    constructor(uint256 initialSupply) ERC20("USD Coin", "USDC") {
+    uint8 private _precision;
+
+    constructor(uint256 initialSupply, uint8 precision) ERC20("USD Coin", "USDC") {
         _mint(msg.sender, initialSupply);
+        _precision = precision;
+    }
+
+    function decimals() public view virtual override returns (uint8) {
+        return _precision;   // the same as the USDC
     }
 
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenizer-prototype",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "",
   "main": "index.js",
   "files": [

--- a/scripts/deploy-test-env.ts
+++ b/scripts/deploy-test-env.ts
@@ -14,7 +14,7 @@ async function main() {
 
     const stablecoin: Contract = (process.env.STABLECOIN) ? 
         await ethers.getContractAt("USDC", process.env.STABLECOIN) :
-        await helpers.deployStablecoin(deployer, "10000000000");
+        await helpers.deployStablecoin(deployer, "10000000000", 6);
 
     const apxRegistry: Contract = (process.env.APX_REGISTRY) ?
         await ethers.getContractAt("ApxAssetsRegistry", process.env.APX_REGISTRY) :

--- a/scripts/faucet.ts
+++ b/scripts/faucet.ts
@@ -1,4 +1,5 @@
 import { ethers } from "hardhat";
+import { parseStablecoin } from "../util/helpers";
 
 async function main() {
     const accounts = await ethers.getSigners();
@@ -11,7 +12,7 @@ async function main() {
     const stablecoin = await ethers.getContractAt("USDC", process.env.STABLECOIN);
     const receiver = process.env.RECEIVER;
     const amount = process.env.AMOUNT || "100000";
-    const amountWei = await ethers.utils.parseEther(amount);
+    const amountWei = await parseStablecoin(amount, stablecoin);
     const tx = await stablecoin.connect(deployer).transfer(receiver, amountWei);
     console.log(`Transfer transaction broadcasted!\n\thash: ${tx.hash}\n\tfrom: ${deployerAddress}\n\tto: ${receiver}\n\tamount: ${amountWei.toString()}`)
     await ethers.provider.waitForTransaction(tx.hash);

--- a/test/TestData.ts
+++ b/test/TestData.ts
@@ -77,7 +77,7 @@ export class TestData {
         this.mark            = accounts[8];
         this.treasury        = accounts[9];
 
-        this.stablecoin = await helpers.deployStablecoin(this.deployer, "1000000000000");
+        this.stablecoin = await helpers.deployStablecoin(this.deployer, "1000000000000", 6);
 
         const factories = await helpers.deployFactories(this.deployer);
         this.issuerFactory = factories[0];
@@ -237,9 +237,9 @@ export class TestData {
 
     async liquidateAsset(liquidationFunds: number = 300000) {
         await this.stablecoin
-            .transfer(await this.issuerOwner.getAddress(), ethers.utils.parseEther(liquidationFunds.toString()));
+            .transfer(await this.issuerOwner.getAddress(), await helpers.parseStablecoin(liquidationFunds, this.stablecoin));
         await this.stablecoin.connect(this.assetManager)
-            .approve(this.asset.address, ethers.utils.parseEther(liquidationFunds.toString()));
+            .approve(this.asset.address, await helpers.parseStablecoin(liquidationFunds, this.stablecoin));
         await helpers
             .registerAsset(this.assetManager, this.apxRegistry, this.asset.address, this.asset.address);
         await helpers.updatePrice(this.priceManager, this.apxRegistry, this.asset, 1, 60);

--- a/test/asset-simple/asset-simple-vesting-flow.ts
+++ b/test/asset-simple/asset-simple-vesting-flow.ts
@@ -43,7 +43,8 @@ describe("Asset simple - full test with vesting schedule", function () {
         testData.alice,
         testData.cfManagerVesting,
         testData.stablecoin,
-        aliceInvestment
+        aliceInvestment,
+        testData.frank
       );
 
       /// Alice tries to invest for Mark's unapproved wallet. Tx should fail.
@@ -53,7 +54,8 @@ describe("Asset simple - full test with vesting schedule", function () {
               testData.mark,
               testData.cfManagerVesting,
               testData.stablecoin,
-              aliceInvestment
+              aliceInvestment,
+              testData.alice
           )
       ).to.be.revertedWith("CfManagerSoftcapVesting: Wallet not whitelisted.");
 

--- a/test/asset-simple/asset-simple-vesting-flow.ts
+++ b/test/asset-simple/asset-simple-vesting-flow.ts
@@ -57,7 +57,7 @@ describe("Asset simple - full test with vesting schedule", function () {
               aliceInvestment,
               testData.alice
           )
-      ).to.be.revertedWith("CfManagerSoftcapVesting: Wallet not whitelisted.");
+      ).to.be.revertedWith("ACfManager: Wallet not whitelisted.");
 
       //// Jane buys $100k USDC and goes through kyc process (wallet approved)
       const janeAddress = await testData.jane.getAddress();

--- a/test/asset-simple/asset-simple-vesting-flow.ts
+++ b/test/asset-simple/asset-simple-vesting-flow.ts
@@ -40,7 +40,6 @@ describe("Asset simple - full test with vesting schedule", function () {
       //// Frank invests $100k USDC credited to the Alice's wallet.
       await helpers.investForBeneficiary(
         testData.frank,
-        testData.frank,
         testData.alice,
         testData.cfManagerVesting,
         testData.stablecoin,
@@ -50,7 +49,6 @@ describe("Asset simple - full test with vesting schedule", function () {
       /// Alice tries to invest for Mark's unapproved wallet. Tx should fail.
       await expect(
           helpers.investForBeneficiary(
-              testData.alice,
               testData.alice,
               testData.mark,
               testData.cfManagerVesting,

--- a/test/asset-simple/asset-simple-vesting-flow.ts
+++ b/test/asset-simple/asset-simple-vesting-flow.ts
@@ -32,7 +32,7 @@ describe("Asset simple - full test with vesting schedule", function () {
       const frankAddress = await testData.frank.getAddress(); 
       const aliceAddress = await testData.alice.getAddress();
       const aliceInvestment = 100000;
-      const aliceInvestmentWei = ethers.utils.parseEther(aliceInvestment.toString());
+      const aliceInvestmentWei = await helpers.parseStablecoin(aliceInvestment, testData.stablecoin);
       await testData.stablecoin.transfer(frankAddress, aliceInvestmentWei);
       await testData.walletApproverService.connect(testData.walletApprover)
           .approveWallet(testData.issuer.address, aliceAddress);
@@ -60,7 +60,7 @@ describe("Asset simple - full test with vesting schedule", function () {
       //// Jane buys $100k USDC and goes through kyc process (wallet approved)
       const janeAddress = await testData.jane.getAddress();
       const janeInvestment = 100000;
-      const janeInvestmentWei: BigNumber = ethers.utils.parseEther(janeInvestment.toString());
+      const janeInvestmentWei: BigNumber = await helpers.parseStablecoin(janeInvestment, testData.stablecoin);
       await testData.stablecoin.transfer(janeAddress, janeInvestmentWei);
       await testData.walletApproverService.connect(testData.walletApprover)
           .approveWallet(testData.issuer.address, janeAddress);
@@ -91,11 +91,13 @@ describe("Asset simple - full test with vesting schedule", function () {
 
       // Alice has to claim tokens after the campaign has been closed successfully
       await testData.cfManagerVesting.connect(testData.alice).claim(aliceAddress);
-      expect(await testData.asset.balanceOf(aliceAddress)).to.be.equal(aliceInvestmentWei); // 1 token = $1
+      const aliceTokenClaimAmount = await ethers.utils.formatEther(await testData.asset.balanceOf(aliceAddress)); 
+      expect(Number(aliceTokenClaimAmount)).to.be.equal(aliceInvestment); // 1 token = $1
 
       // Jane has to claim tokens after the campaign has been closed successfully
       await testData.cfManagerVesting.connect(testData.jane).claim(janeAddress);
-      expect(await testData.asset.balanceOf(janeAddress)).to.be.equal(janeInvestmentWei); // 1 token = $1
+      const janeTokenClaimAmount = await ethers.utils.formatEther(await testData.asset.balanceOf(janeAddress)); 
+      expect(Number(janeTokenClaimAmount)).to.be.equal(janeInvestment); // 1 token = $1
       
       //// Fetch crowdfunding campaign state
       const fetchedCampaignState = await helpers.getCrowdfundingCampaignState(testData.cfManagerVesting);

--- a/test/asset-transferable/asset-transferable-full-flow.ts
+++ b/test/asset-transferable/asset-transferable-full-flow.ts
@@ -13,7 +13,7 @@ describe("Asset transferable - full test", function () {
     await testData.deploy()
   });
 
-  it.only(
+  it(
     `should successfully complete the flow:\n
           1)create Issuer + AssetTransferable + Campaign using deployer service
           2)successfully fund the project with two different investors
@@ -45,7 +45,8 @@ describe("Asset transferable - full test", function () {
           testData.alice,
           testData.cfManager,
           testData.stablecoin,
-          aliceInvestment
+          aliceInvestment,
+          testData.frank
       );
 
       ///// Alice tries to invest for Mark's unapproved wallet. Tx should fail.
@@ -55,7 +56,8 @@ describe("Asset transferable - full test", function () {
             testData.mark,
             testData.cfManager,
             testData.stablecoin,
-            aliceInvestment
+            aliceInvestment,
+            testData.alice
         )
       ).to.be.revertedWith("CfManagerSoftcap: Wallet not whitelisted.");
 

--- a/test/asset-transferable/asset-transferable-full-flow.ts
+++ b/test/asset-transferable/asset-transferable-full-flow.ts
@@ -59,7 +59,7 @@ describe("Asset transferable - full test", function () {
             aliceInvestment,
             testData.alice
         )
-      ).to.be.revertedWith("CfManagerSoftcap: Wallet not whitelisted.");
+      ).to.be.revertedWith("ACfManager: Wallet not whitelisted.");
 
       //// Jane buys $100k USDC and goes through kyc process (wallet approved)
       const janeAddress = await testData.jane.getAddress();

--- a/test/asset-transferable/asset-transferable-full-flow.ts
+++ b/test/asset-transferable/asset-transferable-full-flow.ts
@@ -29,7 +29,7 @@ describe("Asset transferable - full test", function () {
       //// Alice buys $100k USDC and goes through kyc process (wallet approved)
       const aliceAddress = await testData.alice.getAddress();
       const aliceInvestment = 100000;
-      const aliceInvestmentWei = ethers.utils.parseEther(aliceInvestment.toString());
+      const aliceInvestmentWei = await helpers.parseStablecoin(aliceInvestment, testData.stablecoin);
       await testData.stablecoin.transfer(aliceAddress, aliceInvestmentWei);
       await testData.walletApproverService.connect(testData.walletApprover)
           .approveWallet(testData.issuer.address, aliceAddress);
@@ -46,7 +46,7 @@ describe("Asset transferable - full test", function () {
       //// Jane buys $100k USDC and goes through kyc process (wallet approved)
       const janeAddress = await testData.jane.getAddress();
       const janeInvestment = 100000;
-      const janeInvestmentWei: BigNumber = ethers.utils.parseEther(janeInvestment.toString());
+      const janeInvestmentWei: BigNumber = await helpers.parseStablecoin(janeInvestment, testData.stablecoin);
       await testData.stablecoin.transfer(janeAddress, janeInvestmentWei);
       await testData.walletApproverService.connect(testData.walletApprover)
           .approveWallet(testData.issuer.address, janeAddress);
@@ -81,7 +81,7 @@ describe("Asset transferable - full test", function () {
       //// Distribute $100k revenue to the token holders using the snapshot distributor from the step before
       const payoutDescription = "WindFarm Mexico Q3/2021 revenue";
       const revenueAmount = 300000;
-      const revenueAmountWei: BigNumber = ethers.utils.parseEther(revenueAmount.toString());
+      const revenueAmountWei: BigNumber = await helpers.parseStablecoin(revenueAmount, testData.stablecoin);
       const issuerAddress = await testData.issuerOwner.getAddress();
       await testData.stablecoin.transfer(issuerAddress, revenueAmountWei);
       const balanceBeforePayout: BigNumber = await testData.stablecoin.balanceOf(issuerAddress);
@@ -95,7 +95,7 @@ describe("Asset transferable - full test", function () {
       const snapshotId = 1;
       const aliceBalanceBeforePayout = await testData.stablecoin.balanceOf(aliceAddress);
       expect(aliceBalanceBeforePayout).to.be.equal(0);
-      const aliceRevenueShareWei = ethers.utils.parseEther("100000");    // (1/3) of the total revenue payed out
+      const aliceRevenueShareWei = await helpers.parseStablecoin("100000", testData.stablecoin);    // (1/3) of the total revenue payed out
       await helpers.claimRevenue(testData.alice, snapshotDistributor, snapshotId);
       const aliceBalanceAfterPayout = await testData.stablecoin.balanceOf(aliceAddress);
       expect(aliceBalanceAfterPayout).to.be.equal(aliceRevenueShareWei); // alice claims (1/3) of total revenue
@@ -104,7 +104,7 @@ describe("Asset transferable - full test", function () {
       //// SnapshotDistributors address has to be known upfront (can be found for one asset by scanning SnapshotDistributorCreated event for asset address)
       const janeBalanceBeforePayout = await testData.stablecoin.balanceOf(janeAddress);
       expect(janeBalanceBeforePayout).to.be.equal(0);
-      const janeRevenueShareWei = ethers.utils.parseEther("100000");    // (1/3) of the total revenue payed out
+      const janeRevenueShareWei = await helpers.parseStablecoin("100000", testData.stablecoin);    // (1/3) of the total revenue payed out
       await helpers.claimRevenue(testData.jane, snapshotDistributor, snapshotId);
       const janeBalanceAfterPayout = await testData.stablecoin.balanceOf(janeAddress);
       expect(janeBalanceAfterPayout).to.be.equal(janeRevenueShareWei); // jane claims (1/3) of total revenue
@@ -128,9 +128,9 @@ describe("Asset transferable - full test", function () {
       // caller only has to approve the liquidation funds for the rest of the holders.
       // Jane and Alice hold (1/3) of the total supply each, so they can claim $110k each.
       const liquidationAmount = 220000;
-      await testData.stablecoin.transfer(issuerAddress, ethers.utils.parseEther("20000"));
+      await testData.stablecoin.transfer(issuerAddress, await helpers.parseStablecoin("20000", testData.stablecoin));
       const liquidatorBalanceBeforeLiquidation = await testData.stablecoin.balanceOf(issuerAddress);
-      expect (liquidatorBalanceBeforeLiquidation).to.be.equal(ethers.utils.parseEther(liquidationAmount.toString()));
+      expect (liquidatorBalanceBeforeLiquidation).to.be.equal(await helpers.parseStablecoin(liquidationAmount, testData.stablecoin));
       await helpers.liquidate(testData.issuerOwner, testData.asset, testData.stablecoin, liquidationAmount);
       const liquidatorBalanceAfterLiquidation = await testData.stablecoin.balanceOf(issuerAddress);
       expect (liquidatorBalanceAfterLiquidation).to.be.equal(0);
@@ -139,7 +139,7 @@ describe("Asset transferable - full test", function () {
 
       //// Alice claims liquidation share
       const aliceLiquidationShare = 110000;
-      const aliceLiquidationShareWei = ethers.utils.parseEther(aliceLiquidationShare.toString());
+      const aliceLiquidationShareWei = await helpers.parseStablecoin(aliceLiquidationShare, testData.stablecoin);
       await helpers.claimLiquidationShare(testData.alice, testData.asset);
       const aliceBalanceAfterLiquidationClaim = await testData.stablecoin.balanceOf(aliceAddress);
       expect(aliceBalanceAfterLiquidationClaim).to.be.equal(aliceRevenueShareWei.add(aliceLiquidationShareWei));
@@ -147,7 +147,7 @@ describe("Asset transferable - full test", function () {
 
       //// Jane claims liquidation share
       const janeLiquidationShare = 110000;
-      const janeLiquidationShareWei = ethers.utils.parseEther(janeLiquidationShare.toString());
+      const janeLiquidationShareWei = await helpers.parseStablecoin(janeLiquidationShare, testData.stablecoin);
       await helpers.claimLiquidationShare(testData.jane, testData.asset);
       const janeBalanceAfterLiquidationClaim = await testData.stablecoin.balanceOf(janeAddress);
       expect(janeBalanceAfterLiquidationClaim).to.be.equal(janeRevenueShareWei.add(janeLiquidationShareWei));

--- a/test/asset-transferable/asset-transferable-full-flow.ts
+++ b/test/asset-transferable/asset-transferable-full-flow.ts
@@ -13,7 +13,7 @@ describe("Asset transferable - full test", function () {
     await testData.deploy()
   });
 
-  it(
+  it.only(
     `should successfully complete the flow:\n
           1)create Issuer + AssetTransferable + Campaign using deployer service
           2)successfully fund the project with two different investors
@@ -24,52 +24,99 @@ describe("Asset transferable - full test", function () {
     async function () {
       const ASSET_TYPE = "AssetTransferable";
       const CAMPAIGN_TYPE = "CfManagerSoftcap";
+      const issuerOwnerAddress = await testData.issuerOwner.getAddress();
+      const treasuryAddress = await testData.treasury.getAddress();
       await testData.deployIssuerAssetTransferableCampaign()
 
-      //// Alice buys $100k USDC and goes through kyc process (wallet approved)
-      const aliceAddress = await testData.alice.getAddress();
+      //// Frank buys $100k USDC
+      const frankAddress = await testData.frank.getAddress(); 
       const aliceInvestment = 100000;
       const aliceInvestmentWei = await helpers.parseStablecoin(aliceInvestment, testData.stablecoin);
-      await testData.stablecoin.transfer(aliceAddress, aliceInvestmentWei);
+      await testData.stablecoin.transfer(frankAddress, aliceInvestmentWei);
+
+      //// Alice goes through kyc process (wallet approved)
+      const aliceAddress = await testData.alice.getAddress();
       await testData.walletApproverService.connect(testData.walletApprover)
           .approveWallet(testData.issuer.address, aliceAddress);
 
-      //// Alice invests $100k USDC in the project
+      //// Frank spends $100k to invest in the Alice's name. Should succeed: alice is approved and frank wallet is funded
       await helpers.investForBeneficiary(
-          testData.alice,
+          testData.frank,
           testData.alice,
           testData.cfManager,
           testData.stablecoin,
           aliceInvestment
       );
 
+      ///// Alice tries to invest for Mark's unapproved wallet. Tx should fail.
+      await expect(
+        helpers.investForBeneficiary(
+            testData.alice,
+            testData.mark,
+            testData.cfManager,
+            testData.stablecoin,
+            aliceInvestment
+        )
+      ).to.be.revertedWith("CfManagerSoftcap: Wallet not whitelisted.");
+
       //// Jane buys $100k USDC and goes through kyc process (wallet approved)
       const janeAddress = await testData.jane.getAddress();
       const janeInvestment = 100000;
-      const janeInvestmentWei: BigNumber = await helpers.parseStablecoin(janeInvestment, testData.stablecoin);
+      const janeInvestmentWei = await helpers.parseStablecoin(janeInvestment.toString(), testData.stablecoin);
       await testData.stablecoin.transfer(janeAddress, janeInvestmentWei);
       await testData.walletApproverService.connect(testData.walletApprover)
           .approveWallet(testData.issuer.address, janeAddress);
     
       //// Jane invests $100k USDC in the project and then cancels her investment and then invests again
+      //// Cancel invest is called one time before investing again to check if the cancel investment process works well.
       await helpers.invest(testData.jane, testData.cfManager, testData.stablecoin, janeInvestment);
       await helpers.cancelInvest(testData.jane, testData.cfManager);
       await helpers.invest(testData.jane, testData.cfManager, testData.stablecoin, janeInvestment);
 
-      // Asset owner finalizes the campaign as the soft cap has been reached.
+      //// Asset owner finalizes the campaign as the soft cap has been reached. Campaign fee is 10%.
+      //// This tests the case when the default fee is used to calculate the fee amount.
+      const feeNumerator = 1;
+      const feeDenominator = 10;
+      const totalInvestment = janeInvestmentWei.add(aliceInvestmentWei); 
+      const totalFee = totalInvestment.mul(feeNumerator).div(feeDenominator);
+      const fundsRaisedWei = totalInvestment.sub(totalFee);
+      const stablecoinPrecision = await testData.stablecoin.decimals();
+      const fundsRaised = await ethers.utils.formatUnits(fundsRaisedWei, stablecoinPrecision);
+      await helpers.setDefaultFee(testData.feeManager, feeNumerator, feeDenominator);
       await testData.cfManager.connect(testData.issuerOwner).finalize();
+      expect(
+        await testData.stablecoin.balanceOf(issuerOwnerAddress)
+      ).to.be.equal(totalInvestment.sub(totalFee));
+      expect(
+        await testData.stablecoin.balanceOf(treasuryAddress)
+      ).to.be.equal(totalFee);
       
-      // Alice has to claim tokens after the campaign has been closed successfully
+      //// Alice has to claim tokens after the campaign has been closed successfully
       await testData.cfManager.connect(testData.alice).claim(aliceAddress);
-      // Jane has to claim tokens after the campaign has been closed successfully
+      //// Jane has to claim tokens after the campaign has been closed successfully
       await testData.cfManager.connect(testData.jane).claim(janeAddress);
+      //// Test claim balances. Jane and Alice should each own 100k tokens each ($100k investment each at $1/token)
+      
+      const expectedJaneTokenBalance = await ethers.utils.parseEther(janeInvestment.toString());
+      const expectedAliceTokenBalance = await ethers.utils.parseEther(aliceInvestment.toString());
+      expect(await testData.asset.balanceOf(janeAddress)).to.be.equal(expectedJaneTokenBalance);
+      expect(await testData.asset.balanceOf(aliceAddress)).to.be.equal(expectedAliceTokenBalance);
+
+      //// Verify the token can be transferred (send token amount back and forth)
+      const amountToTransfer = await ethers.utils.parseEther("1"); // 1 token
+      await testData.asset.connect(testData.jane).transfer(aliceAddress, amountToTransfer);
+      expect(await testData.asset.balanceOf(janeAddress)).to.be.equal(expectedJaneTokenBalance.sub(amountToTransfer));
+      expect(await testData.asset.balanceOf(aliceAddress)).to.be.equal(expectedAliceTokenBalance.add(amountToTransfer));
+      await testData.asset.connect(testData.alice).transfer(janeAddress, amountToTransfer);
+      expect(await testData.asset.balanceOf(janeAddress)).to.be.equal(expectedJaneTokenBalance);
+      expect(await testData.asset.balanceOf(aliceAddress)).to.be.equal(expectedAliceTokenBalance);
 
       //// Owner creates snapshot distributor, updates info once
       const snapshotDistributorMappedName = "snapshot-distributor";
       const snapshotDistributorInfoHash = "snapshot-distributor-info-hash";
       const updatedSnapshotDistributorInfoHash = "updated-snapshot-distributor-info-hash";
       const snapshotDistributor = await helpers.createSnapshotDistributor(
-          await testData.issuerOwner.getAddress(),
+          issuerOwnerAddress,
           snapshotDistributorMappedName,
           testData.asset,
           snapshotDistributorInfoHash,
@@ -78,67 +125,81 @@ describe("Asset transferable - full test", function () {
       );
       await helpers.setInfo(testData.issuerOwner, snapshotDistributor, updatedSnapshotDistributorInfoHash);
 
-      //// Distribute $100k revenue to the token holders using the snapshot distributor from the step before
+      //// Distribute $300k revenue to the token holders using the snapshot distributor from the step before
+      //// Add self (project owner / distributor) to the ignored addresses when calculating distribution amounts
       const payoutDescription = "WindFarm Mexico Q3/2021 revenue";
       const revenueAmount = 300000;
       const revenueAmountWei: BigNumber = await helpers.parseStablecoin(revenueAmount, testData.stablecoin);
-      const issuerAddress = await testData.issuerOwner.getAddress();
-      await testData.stablecoin.transfer(issuerAddress, revenueAmountWei);
-      const balanceBeforePayout: BigNumber = await testData.stablecoin.balanceOf(issuerAddress);
-      expect(balanceBeforePayout).to.be.equal(revenueAmountWei.add(janeInvestmentWei.mul(2)));
-      await helpers.createPayout(testData.issuerOwner, snapshotDistributor, testData.stablecoin, revenueAmount, payoutDescription);
-      const afterSharePayout = await testData.stablecoin.balanceOf(issuerAddress);
+      await testData.stablecoin.transfer(issuerOwnerAddress, revenueAmountWei);
+      const balanceBeforePayout: BigNumber = await testData.stablecoin.balanceOf(issuerOwnerAddress);
+      expect(balanceBeforePayout).to.be.equal(revenueAmountWei.add(totalInvestment).sub(totalFee));
+      await helpers.createPayout(
+          testData.issuerOwner,
+          snapshotDistributor,
+          testData.stablecoin,
+          revenueAmount,
+          payoutDescription,
+          [ issuerOwnerAddress ]
+      );
+      const afterSharePayout = await testData.stablecoin.balanceOf(issuerOwnerAddress);
       expect(afterSharePayout).to.be.equal(balanceBeforePayout.sub(revenueAmountWei));
 
       //// Alice claims her revenue share by calling previously created SnapshotDistributor contract and providing the payoutId param (0 in this case)
       //// SnapshotDistributor address has to be known upfront (can be found for one asset by scanning SnapshotDistributorCreated event for asset address)
+      //// Alice will receive 1/2 of the total revenue (or $150k) since Alice holds 100k tokens and Jane holds 100k tokens
+      //// (Jane and Alice are the only token holders other the token owner)
       const snapshotId = 1;
       const aliceBalanceBeforePayout = await testData.stablecoin.balanceOf(aliceAddress);
       expect(aliceBalanceBeforePayout).to.be.equal(0);
-      const aliceRevenueShareWei = await helpers.parseStablecoin("100000", testData.stablecoin);    // (1/3) of the total revenue payed out
+      const aliceRevenueShareWei = await helpers.parseStablecoin("150000", testData.stablecoin);    // (1/2) of the total revenue payed out
       await helpers.claimRevenue(testData.alice, snapshotDistributor, snapshotId);
       const aliceBalanceAfterPayout = await testData.stablecoin.balanceOf(aliceAddress);
-      expect(aliceBalanceAfterPayout).to.be.equal(aliceRevenueShareWei); // alice claims (1/3) of total revenue
+      expect(aliceBalanceAfterPayout).to.be.equal(aliceRevenueShareWei);                            // alice claims (1/2) of total revenue
 
       //// Jane claims her revenue share by calling previously created SnapshotDistributor contract and providing the snapshotId param (0 in this case)
       //// SnapshotDistributors address has to be known upfront (can be found for one asset by scanning SnapshotDistributorCreated event for asset address)
+      //// Jane will receive 1/2 of the total revenue (or $150k) since Jane holds 100k tokens and Alice holds 100k tokens
+      //// (Jane and Alice are the only token holders other the token owner)
       const janeBalanceBeforePayout = await testData.stablecoin.balanceOf(janeAddress);
       expect(janeBalanceBeforePayout).to.be.equal(0);
-      const janeRevenueShareWei = await helpers.parseStablecoin("100000", testData.stablecoin);    // (1/3) of the total revenue payed out
+      const janeRevenueShareWei = await helpers.parseStablecoin("150000", testData.stablecoin);     // (1/2) of the total revenue payed out
       await helpers.claimRevenue(testData.jane, snapshotDistributor, snapshotId);
       const janeBalanceAfterPayout = await testData.stablecoin.balanceOf(janeAddress);
-      expect(janeBalanceAfterPayout).to.be.equal(janeRevenueShareWei); // jane claims (1/3) of total revenue
+      expect(janeBalanceAfterPayout).to.be.equal(janeRevenueShareWei);                              // jane claims (1/2) of total revenue
 
       //// Asset is registered on the APX Registry and the market price is updated
+      //// Asset in the APX registry is mapped to itself. This is because MirroredToken is not required since the asset
+      //// is already transferable. But we still need it in the registry to be able to get price feed from the market.
       await helpers.registerAsset(
           testData.assetManager, testData.apxRegistry, testData.asset.address, testData.asset.address
       );
+
       // update market price for asset
       // price: $0.70, expiry: 60 seconds
       await helpers.updatePrice(testData.priceManager, testData.apxRegistry, testData.asset, 11000, 60);
-      console.log("price updated");
 
       //// Asset owner liquidates asset
       // Asset was crowdfunded at $1/token and is now trading at $1.10/token so the total supply must be liquidated
       // at the max($1, $1.10), therefore must be liquidated at the price of $1.10.
-      // Since the asset supply is 300k tokens, liqudiation funds = 300k tokens * $1.10 = $330k
-      // Project owner already holds $200k at his wallet after finalizing the campaign, so we transfer another $20k
-      // to his wallet and call liquidate() function. Liquidate function doesn't require full $330k payment since the
-      // caller holds (1/3) of the token and is entitled to $110k claim. This is deducted in the liquidate() function so
-      // caller only has to approve the liquidation funds for the rest of the holders.
-      // Jane and Alice hold (1/3) of the total supply each, so they can claim $110k each.
+      // Since the asset circulating supply is 200k tokens (jane and alice), liqudiation funds = 200k tokens * $1.10 = $220k
+      // Project owner already holds $200k at his wallet so he needs to buy another $20k of USDC to be able to liquidate.
+      // Alice is entitled to (1/2) and Jane also to (1/2) of the $220k liquidation amount according to their token holdings.
       const liquidationAmount = 220000;
-      await testData.stablecoin.transfer(issuerAddress, await helpers.parseStablecoin("20000", testData.stablecoin));
-      const liquidatorBalanceBeforeLiquidation = await testData.stablecoin.balanceOf(issuerAddress);
-      expect (liquidatorBalanceBeforeLiquidation).to.be.equal(await helpers.parseStablecoin(liquidationAmount, testData.stablecoin));
+      const liquidationAmountWei = await helpers.parseStablecoin(liquidationAmount, testData.stablecoin);
+      await testData.stablecoin.transfer(issuerOwnerAddress, await helpers.parseStablecoin(
+          (liquidationAmount - Number(fundsRaised)),
+          testData.stablecoin)
+      );
+      const liquidatorBalanceBeforeLiquidation = await testData.stablecoin.balanceOf(issuerOwnerAddress);
+      expect(liquidatorBalanceBeforeLiquidation).to.be.equal(liquidationAmountWei);
       await helpers.liquidate(testData.issuerOwner, testData.asset, testData.stablecoin, liquidationAmount);
-      const liquidatorBalanceAfterLiquidation = await testData.stablecoin.balanceOf(issuerAddress);
-      expect (liquidatorBalanceAfterLiquidation).to.be.equal(0);
+      const liquidatorBalanceAfterLiquidation = await testData.stablecoin.balanceOf(issuerOwnerAddress);
+      expect(liquidatorBalanceAfterLiquidation).to.be.equal(0);
       const assetTotalSupply = await testData.asset.totalSupply();
-      expect(await (testData.asset.balanceOf(issuerAddress))).to.be.equal(assetTotalSupply);
+      expect(await (testData.asset.balanceOf(issuerOwnerAddress))).to.be.equal(assetTotalSupply);
 
       //// Alice claims liquidation share
-      const aliceLiquidationShare = 110000;
+      const aliceLiquidationShare = 110000; // liquidationAmount * (1/2)
       const aliceLiquidationShareWei = await helpers.parseStablecoin(aliceLiquidationShare, testData.stablecoin);
       await helpers.claimLiquidationShare(testData.alice, testData.asset);
       const aliceBalanceAfterLiquidationClaim = await testData.stablecoin.balanceOf(aliceAddress);
@@ -146,7 +207,7 @@ describe("Asset transferable - full test", function () {
       expect(await testData.asset.balanceOf(aliceAddress)).to.be.equal(0);
 
       //// Jane claims liquidation share
-      const janeLiquidationShare = 110000;
+      const janeLiquidationShare = 110000;  // liquidationAmount * (1/2)
       const janeLiquidationShareWei = await helpers.parseStablecoin(janeLiquidationShare, testData.stablecoin);
       await helpers.claimLiquidationShare(testData.jane, testData.asset);
       const janeBalanceAfterLiquidationClaim = await testData.stablecoin.balanceOf(janeAddress);

--- a/test/asset-transferable/asset-transferable-full-flow.ts
+++ b/test/asset-transferable/asset-transferable-full-flow.ts
@@ -35,9 +35,7 @@ describe("Asset transferable - full test", function () {
           .approveWallet(testData.issuer.address, aliceAddress);
 
       //// Alice invests $100k USDC in the project
-      const randomCaller = testData.deployer;
       await helpers.investForBeneficiary(
-          randomCaller,
           testData.alice,
           testData.alice,
           testData.cfManager,

--- a/test/asset/asset-full-flow.ts
+++ b/test/asset/asset-full-flow.ts
@@ -60,7 +60,7 @@ describe("Asset - full test", function () {
               aliceInvestment,
               testData.alice
           )
-      ).to.be.revertedWith("CfManagerSoftcap: Wallet not whitelisted.");
+      ).to.be.revertedWith("ACfManager: Wallet not whitelisted.");
 
       //// Jane buys $50k USDC (and another 50k$ to give back to the owner) and goes through kyc process (wallet approved)
       //// Jane will send $50k worth of the tokens back to the owner to test if the tokens are transferable.

--- a/test/asset/asset-full-flow.ts
+++ b/test/asset/asset-full-flow.ts
@@ -33,7 +33,7 @@ describe("Asset - full test", function () {
       const frankAddress = await testData.frank.getAddress(); 
       const aliceAddress = await testData.alice.getAddress();
       const aliceInvestment = 100000;
-      const aliceInvestmentWei = ethers.utils.parseEther(aliceInvestment.toString());
+      const aliceInvestmentWei = await helpers.parseStablecoin(aliceInvestment, testData.stablecoin);
       await testData.stablecoin.transfer(frankAddress, aliceInvestmentWei);
       await testData.walletApproverService.connect(testData.walletApprover)
           .approveWallet(testData.issuer.address, aliceAddress);
@@ -61,7 +61,7 @@ describe("Asset - full test", function () {
       //// Jane buys $100k USDC and goes through kyc process (wallet approved)
       const janeAddress = await testData.jane.getAddress();
       const janeInvestment = 100000;
-      const janeInvestmentWei = ethers.utils.parseEther(janeInvestment.toString());
+      const janeInvestmentWei = await helpers.parseStablecoin(janeInvestment.toString(), testData.stablecoin);
       await testData.stablecoin.transfer(janeAddress, janeInvestmentWei);
       await testData.walletApproverService.connect(testData.walletApprover)
           .approveWallet(testData.issuer.address, janeAddress);
@@ -106,7 +106,7 @@ describe("Asset - full test", function () {
       //// Distribute $100k revenue to the token holders using the snapshot distributor from the step before
       const payoutDescription = "WindFarm Mexico Q3/2021 revenue";
       const revenueAmount = 300000;
-      const revenueAmountWei = ethers.utils.parseEther(revenueAmount.toString());
+      const revenueAmountWei = await helpers.parseStablecoin(revenueAmount, testData.stablecoin);
       const issuerAddress = await testData.issuerOwner.getAddress();
       await testData.stablecoin.transfer(issuerAddress, revenueAmountWei);
       const balanceBeforePayout: BigNumber = await testData.stablecoin.balanceOf(issuerAddress);
@@ -122,7 +122,7 @@ describe("Asset - full test", function () {
       const snapshotId = 1;
       const aliceBalanceBeforePayout = await testData.stablecoin.balanceOf(aliceAddress);
       expect(aliceBalanceBeforePayout).to.be.equal(0);
-      const aliceRevenueShareWei = ethers.utils.parseEther("100000");    // (1/3) of the total revenue payed out
+      const aliceRevenueShareWei = await helpers.parseStablecoin("100000", testData.stablecoin);    // (1/3) of the total revenue payed out
       await helpers.claimRevenue(testData.alice, snapshotDistributor, snapshotId)
       const aliceBalanceAfterPayout = await testData.stablecoin.balanceOf(aliceAddress);
       expect(aliceBalanceAfterPayout).to.be.equal(aliceRevenueShareWei); // alice claims (1/3) of total revenue
@@ -131,7 +131,7 @@ describe("Asset - full test", function () {
       //// SnapshotDistributors address has to be known upfront (can be found for one asset by scanning SnapshotDistributorCreated event for asset address)
       const janeBalanceBeforePayout = await testData.stablecoin.balanceOf(janeAddress);
       expect(janeBalanceBeforePayout).to.be.equal(0);
-      const janeRevenueShareWei = ethers.utils.parseEther("100000");    // (1/3) of the total revenue payed out
+      const janeRevenueShareWei = await helpers.parseStablecoin("100000", testData.stablecoin);    // (1/3) of the total revenue payed out
       await helpers.claimRevenue(testData.jane, snapshotDistributor, snapshotId);
       const janeBalanceAfterPayout = await testData.stablecoin.balanceOf(janeAddress);
       expect(janeBalanceAfterPayout).to.be.equal(janeRevenueShareWei); // jane claims (1/3) of total revenue
@@ -173,9 +173,9 @@ describe("Asset - full test", function () {
       // caller only has to approve the liquidation funds for the rest of the holders.
       // Jane and Alice hold (1/3) of the total supply each, so they can claim $110k each.
       const liquidationAmount = 220000;
-      await testData.stablecoin.transfer(issuerAddress, ethers.utils.parseEther("40000"));
+      await testData.stablecoin.transfer(issuerAddress, await helpers.parseStablecoin("40000", testData.stablecoin));
       const liquidatorBalanceBeforeLiquidation = await testData.stablecoin.balanceOf(issuerAddress);
-      expect (liquidatorBalanceBeforeLiquidation).to.be.equal(ethers.utils.parseEther(liquidationAmount.toString()));
+      expect (liquidatorBalanceBeforeLiquidation).to.be.equal(await helpers.parseStablecoin(liquidationAmount, testData.stablecoin));
       await helpers.liquidate(testData.issuerOwner, testData.asset, testData.stablecoin, liquidationAmount);
       const liquidatorBalanceAfterLiquidation = await testData.stablecoin.balanceOf(issuerAddress);
       expect (liquidatorBalanceAfterLiquidation).to.be.equal(0);
@@ -184,7 +184,7 @@ describe("Asset - full test", function () {
 
       //// Alice claims liquidation share
       const aliceLiquidationShare = 110000;
-      const aliceLiquidationShareWei = ethers.utils.parseEther(aliceLiquidationShare.toString());
+      const aliceLiquidationShareWei = await helpers.parseStablecoin(aliceLiquidationShare, testData.stablecoin);
       await helpers.claimLiquidationShare(testData.alice, testData.asset);
       const aliceBalanceAfterLiquidationClaim = await testData.stablecoin.balanceOf(aliceAddress);
       expect(aliceBalanceAfterLiquidationClaim).to.be.equal(aliceRevenueShareWei.add(aliceLiquidationShareWei));
@@ -193,7 +193,7 @@ describe("Asset - full test", function () {
       //// Jane converts mirrored to original and claims liquidation share
       await mirroredAsset.connect(testData.jane).burnMirrored(tokensToMirror);
       const janeLiquidationShare = 110000;
-      const janeLiquidationShareWei = ethers.utils.parseEther(janeLiquidationShare.toString());
+      const janeLiquidationShareWei = await helpers.parseStablecoin(janeLiquidationShare, testData.stablecoin);
       await helpers.claimLiquidationShare(testData.jane, testData.asset);
       const janeBalanceAfterLiquidationClaim = await testData.stablecoin.balanceOf(janeAddress);
       expect(janeBalanceAfterLiquidationClaim).to.be.equal(janeRevenueShareWei.add(janeLiquidationShareWei));
@@ -202,6 +202,9 @@ describe("Asset - full test", function () {
       //// Fetch crowdfunding campaign state
       // const fetchedCampaignState = await helpers.getCrowdfundingCampaignState(testData.cfManager);
       const state = await testData.cfManager.getState()
+      const stablecoinDecimals = await testData.stablecoin.decimals();
+      const expectedTotalTokensSold = await ethers.utils.formatUnits(totalInvestment.toString(), stablecoinDecimals);
+      const fetchedTotalTokensSold = await ethers.utils.formatEther(state.totalTokensSold.toString());
       console.log("fetched crowdfunding campaign state", state);
       expect(state.issuer).to.be.equal(testData.issuer.address)
       expect(state.owner).to.be.equal(await testData.issuerOwner.getAddress())
@@ -211,12 +214,12 @@ describe("Asset - full test", function () {
       expect(state.finalized).to.be.true
       expect(state.whitelistRequired).to.be.true
       expect(state.info).to.be.equal(testData.campaignInfoHash)
-      expect(state.totalFundsRaised, "totalFundsRaised").to.be.equal(totalInvestment)
-      expect(state.totalTokensSold, "totalTokensSold").to.be.equal(totalInvestment)
+      expect(state.totalFundsRaised, "totalFundsRaised").to.be.equal(totalInvestment.toString())
+      expect(fetchedTotalTokensSold, "totalTokensSold").to.be.equal(expectedTotalTokensSold)
       expect(state.tokenPrice, "tokenPrice").to.be.equal(testData.campaignInitialPricePerToken)
-      expect(state.minInvestment, "minInvestment").to.be.equal(ethers.utils.parseEther(testData.campaignMinInvestment.toString()))
-      expect(state.maxInvestment, "maxInvestment").to.be.equal(ethers.utils.parseEther(testData.campaignMaxInvestment.toString()))
-      expect(state.softCap, "softCap").to.be.equal(ethers.utils.parseEther(testData.campaignSoftCap.toString()))
+      expect(state.minInvestment, "minInvestment").to.be.equal(await helpers.parseStablecoin(testData.campaignMinInvestment, testData.stablecoin))
+      expect(state.maxInvestment, "maxInvestment").to.be.equal(await helpers.parseStablecoin(testData.campaignMaxInvestment, testData.stablecoin))
+      expect(state.softCap, "softCap").to.be.equal(await helpers.parseStablecoin(testData.campaignSoftCap, testData.stablecoin))
       expect(state.totalInvestorsCount, "totalInvestorsCount").to.be.equal(2)
       expect(state.totalClaimsCount, "totalClaimsCount").to.be.equal(2)
       expect(state.totalClaimableTokens, "totalClaimableTokens").to.be.equal(0)

--- a/test/asset/asset-full-flow.ts
+++ b/test/asset/asset-full-flow.ts
@@ -38,10 +38,8 @@ describe("Asset - full test", function () {
       await testData.walletApproverService.connect(testData.walletApprover)
           .approveWallet(testData.issuer.address, aliceAddress);
 
-      const randomCaller = testData.deployer;
       //// Frank invests $100k credited to the Alice's wallet
       await helpers.investForBeneficiary(
-          randomCaller,
           testData.frank,
           testData.alice,
           testData.cfManager,
@@ -52,7 +50,6 @@ describe("Asset - full test", function () {
       ///// Alice tries to invest for Mark's unapproved wallet. Tx should fail.
       await expect(
           helpers.investForBeneficiary(
-              randomCaller,
               testData.alice,
               testData.mark,
               testData.cfManager,

--- a/test/asset/asset-full-flow.ts
+++ b/test/asset/asset-full-flow.ts
@@ -29,16 +29,18 @@ describe("Asset - full test", function () {
       const treasuryAddress = await testData.treasury.getAddress();
       await testData.deployIssuerAssetClassicCampaign()
 
-      //// Alice buys $100k USDC and goes through kyc process (wallet approved)
+      //// Frank buys $100k USDC
       const frankAddress = await testData.frank.getAddress(); 
-      const aliceAddress = await testData.alice.getAddress();
       const aliceInvestment = 100000;
       const aliceInvestmentWei = await helpers.parseStablecoin(aliceInvestment, testData.stablecoin);
       await testData.stablecoin.transfer(frankAddress, aliceInvestmentWei);
+
+      //// Alice goes through kyc process (wallet approved)
+      const aliceAddress = await testData.alice.getAddress();
       await testData.walletApproverService.connect(testData.walletApprover)
           .approveWallet(testData.issuer.address, aliceAddress);
 
-      //// Frank invests $100k credited to the Alice's wallet
+      //// Frank spends $100k to invest in the Alice's name. Should succeed: alice is approved and frank wallet is funded
       await helpers.investForBeneficiary(
           testData.frank,
           testData.alice,
@@ -58,23 +60,38 @@ describe("Asset - full test", function () {
           )
       ).to.be.revertedWith("CfManagerSoftcap: Wallet not whitelisted.");
 
-      //// Jane buys $100k USDC and goes through kyc process (wallet approved)
+      //// Jane buys $50k USDC (and another 50k$ to give back to the owner) and goes through kyc process (wallet approved)
+      //// Jane will send $50k worth of the tokens back to the owner to test if the tokens are transferable.
+      //// This asset type forbids token transfer in general, but allows sending tokens to the asset owner.
       const janeAddress = await testData.jane.getAddress();
-      const janeInvestment = 100000;
-      const janeInvestmentWei = await helpers.parseStablecoin(janeInvestment.toString(), testData.stablecoin);
+      const janeInvestment = 50000;
+      const janeAdditionalInvestment = 50000;
+      const janeTotalInvestment = janeInvestment + janeAdditionalInvestment;
+      const janeInvestmentWei = await helpers.parseStablecoin((janeTotalInvestment).toString(), testData.stablecoin);
       await testData.stablecoin.transfer(janeAddress, janeInvestmentWei);
       await testData.walletApproverService.connect(testData.walletApprover)
           .approveWallet(testData.issuer.address, janeAddress);
 
-      await helpers.invest(testData.jane, testData.cfManager, testData.stablecoin, janeInvestment);
+      //// Jane invests $50k + $50k. The additional $50k of tokens will be transferred back to the project owner wallet
+      //// Cancel invest is called one time before investing again to check if the cancel investment process works well.
+      await helpers.invest(testData.jane, testData.cfManager, testData.stablecoin, janeTotalInvestment);
+      expect(await testData.stablecoin.balanceOf(janeAddress)).to.be.equal(0);
       await helpers.cancelInvest(testData.jane, testData.cfManager);
-      await helpers.invest(testData.jane, testData.cfManager, testData.stablecoin, janeInvestment);
+      expect(
+          await testData.stablecoin.balanceOf(janeAddress)
+      ).to.be.equal(await helpers.parseStablecoin(janeTotalInvestment, testData.stablecoin));
+      await helpers.invest(testData.jane, testData.cfManager, testData.stablecoin, janeTotalInvestment);
 
-      // Asset owner finalizes the campaign as the soft cap has been reached. Campaign fee is 10%.
+      //// Asset owner finalizes the campaign as the soft cap has been reached. Campaign fee is 10%.
+      //// This tests the case when the default fee (1/5 = 20%) is overriden by the per-campaign-basis fee (1/10 = 10%).
       const feeNumerator = 1;
       const feeDenominator = 10;
       const totalInvestment = janeInvestmentWei.add(aliceInvestmentWei); 
       const totalFee = totalInvestment.mul(feeNumerator).div(feeDenominator);
+      const fundsRaisedWei = totalInvestment.sub(totalFee);
+      const stablecoinPrecision = await testData.stablecoin.decimals();
+      const fundsRaised = await ethers.utils.formatUnits(fundsRaisedWei, stablecoinPrecision);
+      await helpers.setDefaultFee(testData.feeManager, 1, 5);
       await helpers.setFeeForCampaign(testData.feeManager, testData.cfManager.address, feeNumerator, feeDenominator);
       await testData.cfManager.connect(testData.issuerOwner).finalize();
       expect(
@@ -84,10 +101,39 @@ describe("Asset - full test", function () {
           await testData.stablecoin.balanceOf(treasuryAddress)
       ).to.be.equal(totalFee);
 
-      // Alice has to claim tokens after the campaign has been closed successfully
+      //// Alice has to claim tokens after the campaign has been closed successfully
       await testData.cfManager.connect(testData.alice).claim(aliceAddress);
-      // Jane has to claim tokens after the campaign has been closed successfully
+      //// Jane has to claim tokens after the campaign has been closed successfully
       await testData.cfManager.connect(testData.jane).claim(janeAddress);
+      //// Test claim balances. Jane and Alice should each own 100k tokens each ($100k investment each at $1/token)
+      expect(await testData.asset.balanceOf(janeAddress)).to.be.equal(
+        await ethers.utils.parseEther(janeTotalInvestment.toString())
+      );
+      expect(await testData.asset.balanceOf(aliceAddress)).to.be.equal(
+        await ethers.utils.parseEther(aliceInvestment.toString())
+      );
+
+      //// Test sending tokens to the asset owner wallet (janeAdditionalInvestment).
+      //// Jane sends half of her tokens (50k out of 100k) back to the asset owner
+      await testData.asset.connect(testData.jane).transfer(
+          testData.issuerOwner.getAddress(),
+          await ethers.utils.parseEther(janeAdditionalInvestment.toString())
+      );
+
+      //// After Jane sends back janeAdditionalTokens, Alice owns 100k tokens while Jane is left with 50k of tokens
+      const janePostInvestmentTokenBalance = await testData.asset.balanceOf(janeAddress);
+      const alicePostInvestmentTokenBalance = await testData.asset.balanceOf(aliceAddress);
+      expect(janePostInvestmentTokenBalance).to.be.equal(
+          await ethers.utils.parseEther(janeInvestment.toString())
+      );
+      expect(alicePostInvestmentTokenBalance).to.be.equal(
+          await ethers.utils.parseEther(aliceInvestment.toString())
+      );
+      
+      //// Verify tokens can't be transfered
+      await expect(
+        testData.asset.connect(testData.alice).transfer(janeAddress, 1000)
+      ).to.be.reverted;
 
       //// Owner creates snapshot distributor, updates info once
       const snapshotDistributorMappedName = "snapshot-manager";
@@ -103,32 +149,41 @@ describe("Asset - full test", function () {
       );
       await helpers.setInfo(testData.issuerOwner, snapshotDistributor, updatedSnapshotDistributorInfoHash);
 
-      //// Distribute $100k revenue to the token holders using the snapshot distributor from the step before
+      //// Distribute $300k revenue to the token holders using the snapshot distributor from the step before
+      //// Add self (project owner / distributor) to the ignored addresses when calculating distribution amounts
       const payoutDescription = "WindFarm Mexico Q3/2021 revenue";
       const revenueAmount = 300000;
       const revenueAmountWei = await helpers.parseStablecoin(revenueAmount, testData.stablecoin);
-      const issuerAddress = await testData.issuerOwner.getAddress();
-      await testData.stablecoin.transfer(issuerAddress, revenueAmountWei);
-      const balanceBeforePayout: BigNumber = await testData.stablecoin.balanceOf(issuerAddress);
+      await testData.stablecoin.transfer(issuerOwnerAddress, revenueAmountWei);
+      const balanceBeforePayout: BigNumber = await testData.stablecoin.balanceOf(issuerOwnerAddress);
       expect(balanceBeforePayout).to.be.equal(revenueAmountWei.add(totalInvestment).sub(totalFee));
       await helpers.createPayout(
-          testData.issuerOwner, snapshotDistributor, testData.stablecoin, revenueAmount, payoutDescription
+          testData.issuerOwner,
+          snapshotDistributor,
+          testData.stablecoin,
+          revenueAmount,
+          payoutDescription,
+          [ issuerOwnerAddress ]
       );
-      const afterSharePayout = await testData.stablecoin.balanceOf(issuerAddress);
+      const afterSharePayout = await testData.stablecoin.balanceOf(issuerOwnerAddress);
       expect(afterSharePayout).to.be.equal(balanceBeforePayout.sub(revenueAmountWei));
 
       //// Alice claims her revenue share by calling previously created SnapshotDistributor contract and providing the snapshotId param (0 in this case)
       //// SnapshotDistributor address has to be known upfront (can be found for one asset by scanning SnapshotDistributorCreated event for asset address)
+      //// Alice will receive 2/3 of the total revenue (or $200k) since Alice holds 100k tokens and Jane holds 50k tokens
+      //// (Jane and Alice are the only token holders other the token owner)
       const snapshotId = 1;
       const aliceBalanceBeforePayout = await testData.stablecoin.balanceOf(aliceAddress);
       expect(aliceBalanceBeforePayout).to.be.equal(0);
-      const aliceRevenueShareWei = await helpers.parseStablecoin("100000", testData.stablecoin);    // (1/3) of the total revenue payed out
+      const aliceRevenueShareWei = await helpers.parseStablecoin("200000", testData.stablecoin);    // (2/3) of the total revenue payed out
       await helpers.claimRevenue(testData.alice, snapshotDistributor, snapshotId)
       const aliceBalanceAfterPayout = await testData.stablecoin.balanceOf(aliceAddress);
-      expect(aliceBalanceAfterPayout).to.be.equal(aliceRevenueShareWei); // alice claims (1/3) of total revenue
+      expect(aliceBalanceAfterPayout).to.be.equal(aliceRevenueShareWei); // alice claims (2/3) of total revenue
 
       //// Jane claims her revenue share by calling previously created SnapshotDistributor contract and providing the snapshotId param (0 in this case)
       //// SnapshotDistributors address has to be known upfront (can be found for one asset by scanning SnapshotDistributorCreated event for asset address)
+      //// Jane will receive 1/3 of the total revenue (or $100k) since Jane holds 50k tokens and ALice holds 100k tokens
+      //// (Jane and Alice are the only token holders other the token owner)
       const janeBalanceBeforePayout = await testData.stablecoin.balanceOf(janeAddress);
       expect(janeBalanceBeforePayout).to.be.equal(0);
       const janeRevenueShareWei = await helpers.parseStablecoin("100000", testData.stablecoin);    // (1/3) of the total revenue payed out
@@ -149,7 +204,7 @@ describe("Asset - full test", function () {
       );
 
       //// Jane mirrors her tokens
-      const tokensToMirror = ethers.utils.parseEther("100000"); // all of the jane tokens will be mirrored
+      const tokensToMirror = ethers.utils.parseEther("50000"); // all of the jane tokens will be mirrored
       await testData.asset.connect(testData.jane).approve(testData.asset.address, tokensToMirror);
       await testData.asset.connect(testData.jane).lockTokens(tokensToMirror);
       const janePostLockAssetBalance = await testData.asset.balanceOf(janeAddress);
@@ -159,31 +214,28 @@ describe("Asset - full test", function () {
       const mirroredTokenSupply = await mirroredAsset.totalSupply();
       expect(mirroredTokenSupply).to.be.equal(tokensToMirror);
 
-      // update market price for asset
-      // price: $0.70, expiry: 60 seconds
+      ////// update market price for asset
+      ////// price: $0.70, expiry: 60 seconds
       await helpers.updatePrice(testData.priceManager, testData.apxRegistry, mirroredAsset, 11000, 60);
 
       //// Asset owner liquidates asset
       // Asset was crowdfunded at $1/token and is now trading at $1.10/token so the total supply must be liquidated
       // at the max($1, $1.10), therefore must be liquidated at the price of $1.10.
-      // Since the asset supply is 300k tokens, liqudiation funds = 300k tokens * $1.10 = $330k
-      // Project owner already holds $200k at his wallet after finalizing the campaign, so we transfer another $20k
-      // to his wallet and call liquidate() function. Liquidate function doesn't require full $330k payment since the
-      // caller holds (1/3) of the token and is entitled to $110k claim. This is deducted in the liquidate() function so
-      // caller only has to approve the liquidation funds for the rest of the holders.
-      // Jane and Alice hold (1/3) of the total supply each, so they can claim $110k each.
-      const liquidationAmount = 220000;
-      await testData.stablecoin.transfer(issuerAddress, await helpers.parseStablecoin("40000", testData.stablecoin));
-      const liquidatorBalanceBeforeLiquidation = await testData.stablecoin.balanceOf(issuerAddress);
-      expect (liquidatorBalanceBeforeLiquidation).to.be.equal(await helpers.parseStablecoin(liquidationAmount, testData.stablecoin));
+      // Since the asset circulating supply is 150k tokens (jane and alice), liqudiation funds = 150k tokens * $1.10 = $165k
+      // Project owner already holds $200k at his wallet after finalizing the campaign so he is good to go.
+      // Alice is entitled to (2/3) and Jane to (1/3) of the $165k liquidation amount according to their token holdings.
+      const liquidationAmount = 165000;
+      const liquidationAmountWei = await helpers.parseStablecoin(liquidationAmount, testData.stablecoin);
+      const liquidatorBalanceBeforeLiquidation = await testData.stablecoin.balanceOf(issuerOwnerAddress);
+      expect(liquidatorBalanceBeforeLiquidation).to.be.equal(fundsRaisedWei);
       await helpers.liquidate(testData.issuerOwner, testData.asset, testData.stablecoin, liquidationAmount);
-      const liquidatorBalanceAfterLiquidation = await testData.stablecoin.balanceOf(issuerAddress);
-      expect (liquidatorBalanceAfterLiquidation).to.be.equal(0);
+      const liquidatorBalanceAfterLiquidation = await testData.stablecoin.balanceOf(issuerOwnerAddress);
+      expect(liquidatorBalanceAfterLiquidation).to.be.equal(fundsRaisedWei.sub(liquidationAmountWei));
       const assetTotalSupply = await testData.asset.totalSupply();
       expect(await (testData.asset.balanceOf(issuerOwnerAddress))).to.be.equal(assetTotalSupply);
 
       //// Alice claims liquidation share
-      const aliceLiquidationShare = 110000;
+      const aliceLiquidationShare = 110000; // liquidationAmount * (2/3) 
       const aliceLiquidationShareWei = await helpers.parseStablecoin(aliceLiquidationShare, testData.stablecoin);
       await helpers.claimLiquidationShare(testData.alice, testData.asset);
       const aliceBalanceAfterLiquidationClaim = await testData.stablecoin.balanceOf(aliceAddress);
@@ -192,7 +244,7 @@ describe("Asset - full test", function () {
 
       //// Jane converts mirrored to original and claims liquidation share
       await mirroredAsset.connect(testData.jane).burnMirrored(tokensToMirror);
-      const janeLiquidationShare = 110000;
+      const janeLiquidationShare = 55000;   // liquidationAmount * (1/3)
       const janeLiquidationShareWei = await helpers.parseStablecoin(janeLiquidationShare, testData.stablecoin);
       await helpers.claimLiquidationShare(testData.jane, testData.asset);
       const janeBalanceAfterLiquidationClaim = await testData.stablecoin.balanceOf(janeAddress);
@@ -200,7 +252,6 @@ describe("Asset - full test", function () {
       expect(await testData.asset.balanceOf(janeAddress)).to.be.equal(0);
 
       //// Fetch crowdfunding campaign state
-      // const fetchedCampaignState = await helpers.getCrowdfundingCampaignState(testData.cfManager);
       const state = await testData.cfManager.getState()
       const stablecoinDecimals = await testData.stablecoin.decimals();
       const expectedTotalTokensSold = await ethers.utils.formatUnits(totalInvestment.toString(), stablecoinDecimals);

--- a/test/asset/asset-full-flow.ts
+++ b/test/asset/asset-full-flow.ts
@@ -46,7 +46,8 @@ describe("Asset - full test", function () {
           testData.alice,
           testData.cfManager,
           testData.stablecoin,
-          aliceInvestment
+          aliceInvestment,
+          testData.frank
       );
 
       ///// Alice tries to invest for Mark's unapproved wallet. Tx should fail.
@@ -56,7 +57,8 @@ describe("Asset - full test", function () {
               testData.mark,
               testData.cfManager,
               testData.stablecoin,
-              aliceInvestment
+              aliceInvestment,
+              testData.alice
           )
       ).to.be.revertedWith("CfManagerSoftcap: Wallet not whitelisted.");
 

--- a/test/campaign/campaign-deployer.ts
+++ b/test/campaign/campaign-deployer.ts
@@ -1,0 +1,53 @@
+// @ts-ignore
+import { ethers } from "hardhat";
+import { Contract } from "ethers";
+
+export async function createCampaign(
+    owner: String,
+    mappedName: String,
+    asset: Contract,
+    pricePerToken: Number,
+    softCapWei: Number,
+    minInvestmentWei: Number,
+    maxInvestmentWei: Number,
+    whitelistRequired: boolean,
+    info: String,
+    cfManagerFactory: Contract,
+    nameRegistry: Contract,
+    feeRegistry: Contract
+  ): Promise<Contract> {
+    const cfManagerTx = await cfManagerFactory.create(
+      owner,
+      mappedName,
+      asset.address,
+      pricePerToken,
+      softCapWei,
+      minInvestmentWei,
+      maxInvestmentWei,
+      whitelistRequired,
+      info,
+      nameRegistry.address,
+      feeRegistry.address
+    );
+    const receipt = await ethers.provider.waitForTransaction(cfManagerTx.hash);
+    for (const log of receipt.logs) {
+      try {
+        const parsedLog = cfManagerFactory.interface.parseLog(log);
+        if (parsedLog.name == "CfManagerSoftcapCreated") {
+          const ownerAddress = parsedLog.args.creator;
+          const cfManagerAddress = parsedLog.args.cfManager;
+          const assetAddress = parsedLog.args.asset;
+          console.log(`\nCrowdfunding Campaign deployed\n\tAt address: ${cfManagerAddress}\n\tOwner: ${ownerAddress}\n\tAsset: ${assetAddress}`);
+          return (await ethers.getContractAt("CfManagerSoftcap", cfManagerAddress));
+        }
+        if (parsedLog.name == "CfManagerSoftcapVestingCreated") {
+            const ownerAddress = parsedLog.args.creator;
+            const cfManagerAddress = parsedLog.args.cfManager;
+            const assetAddress = parsedLog.args.asset;
+            console.log(`\nCrowdfunding Campaign [Vesting] deployed\n\tAt address: ${cfManagerAddress}\n\tOwner: ${ownerAddress}\n\tAsset: ${assetAddress}`);
+            return (await ethers.getContractAt("CfManagerSoftcapVesting", cfManagerAddress));
+        }
+      } catch (_) {}
+    }
+    throw new Error("Campaign creation transaction failed.");
+  }

--- a/test/campaign/campaign-tests.ts
+++ b/test/campaign/campaign-tests.ts
@@ -1,0 +1,99 @@
+// // @ts-ignore
+// import { ethers } from "hardhat";
+// import { expect } from "chai";
+// import * as helpers from "../../util/helpers";
+// import { TestData } from "../TestData";
+// import { BigNumber, Contract, Signer } from "ethers";
+// import { advanceBlockTime } from "../../util/utils";
+
+// describe("Covers important tests for all campaign flavors", function () {
+
+//   const testData = new TestData()
+//   let issuerOwner: Signer;
+//   let issuerOwnerAddress: String;
+//   let campaign: Contract;
+//   let canceledCampaign: Contract;
+
+//   before(async function () {
+//     await testData.deploy()
+//     await testData.deployIssuerAssetClassicCampaign();
+//     issuerOwner = testData.issuerOwner;
+//     issuerOwnerAddress = await issuerOwner.getAddress();
+//     campaign = testData.cfManager;
+//     canceledCampaign = await helpers.createCfManager(
+//         issuerOwnerAddress,
+//         "canceled-campaign",
+//         testData.asset,
+//         10000,       // $1 price per token
+//         10000,       // $10k softCap
+//         1000,        // $1k min per user investment
+//         100000,      // $100k max per user investment
+//         true, "",
+//         testData.cfManagerFactory,
+//         testData.nameRegistry
+//     );
+//   });
+
+//   it.skip(`should check for regular campaign:
+//         - can be closed if 1 wei left until softcap
+//         - can cancel investments by anyone if the campaign has been cancelled
+//         - fails to cancel investments by anyone if the campaign is still active
+//         - anyone can process someone's investment if the approval exists
+//         - anyone can invest for someone else
+//         - i can invest for myself
+//         - noone can take my approval and process investment as his own
+//   `, async function () {
+//       /**
+//        * Configuration:
+//        *   asset supply: 1M tokens
+//        *   asset precision: 10 ** 18
+//        *   asset token amount for sale (wei): 190270270270270270270270
+//        *   stablecoin precision: 10 ** 6 
+//        *   soft cap (wei): 2111999997
+//        *   price per token: 111
+//        *   min per user investment (wei): 550000000
+//        *   max per user investment (wei): 2000000000
+//        * 
+//        * Two investors participating in following usdc amounts (wei):
+//        *   investor 1: 552299999
+//        *   investor 2: 1559699997
+//        */
+      
+//       const ASSET_TYPE = "AssetSimple";
+//       const CAMPAIGN_TYPE = "CfManagerSoftcap";
+//       const issuerOwnerAddress = await testData.issuerOwner.getAddress();
+//       const treasuryAddress = await testData.treasury.getAddress();
+
+//       const frankAddress = await testData.frank.getAddress(); 
+//       const aliceAddress = await testData.alice.getAddress();
+    
+//       //// Frank calls approve and investForBeneficiary() by himself
+
+//       //// Alice tries to cancel Frank's investment (should fail since the campaign is active)
+
+//       //// Frank cancels his investment
+
+//       //// Frank calls approve and invest() by himself
+
+//       //// Alice calls approve and Frank tries to process Alice's investment as his own (should fail)
+
+//       //// Frank processes Alice's investment
+
+//       const aliceInvestment = 100000;
+//       const aliceInvestmentWei = ethers.utils.parseEther(aliceInvestment.toString());
+//       await testData.stablecoin.transfer(frankAddress, aliceInvestmentWei);
+//       await testData.walletApproverService.connect(testData.walletApprover)
+//           .approveWallet(testData.issuer.address, aliceAddress);
+
+//       //// Frank invests $100k USDC credited to the Alice's wallet.
+//       await helpers.investForBeneficiary(
+//         testData.frank,
+//         testData.alice,
+//         testData.cfManagerVesting,
+//         testData.stablecoin,
+//         aliceInvestment
+//       );
+
+//     });
+
+// });

--- a/test/campaign/campaign-tests.ts
+++ b/test/campaign/campaign-tests.ts
@@ -1,99 +1,332 @@
-// // @ts-ignore
-// import { ethers } from "hardhat";
-// import { expect } from "chai";
-// import * as helpers from "../../util/helpers";
-// import { TestData } from "../TestData";
-// import { BigNumber, Contract, Signer } from "ethers";
-// import { advanceBlockTime } from "../../util/utils";
+// @ts-ignore
+import { ethers } from "hardhat";
+import { expect } from "chai";
+import * as helpers from "../../util/helpers";
+import { TestData } from "../TestData";
+import { BigNumber, Signer } from "ethers";
+import { createCampaign } from "./campaign-deployer";
 
-// describe("Covers important tests for all campaign flavors", function () {
+describe("Covers important tests for all campaign flavors", function () {
 
-//   const testData = new TestData()
-//   let issuerOwner: Signer;
-//   let issuerOwnerAddress: String;
-//   let campaign: Contract;
-//   let canceledCampaign: Contract;
+  const testData = new TestData()
+  let issuerOwner: Signer;
+  let issuerOwnerAddress: String;
 
-//   before(async function () {
-//     await testData.deploy()
-//     await testData.deployIssuerAssetClassicCampaign();
-//     issuerOwner = testData.issuerOwner;
-//     issuerOwnerAddress = await issuerOwner.getAddress();
-//     campaign = testData.cfManager;
-//     canceledCampaign = await helpers.createCfManager(
-//         issuerOwnerAddress,
-//         "canceled-campaign",
-//         testData.asset,
-//         10000,       // $1 price per token
-//         10000,       // $10k softCap
-//         1000,        // $1k min per user investment
-//         100000,      // $100k max per user investment
-//         true, "",
-//         testData.cfManagerFactory,
-//         testData.nameRegistry
-//     );
-//   });
+  before(async function () {
+    await testData.deploy()
+    await testData.deployIssuer();
+    issuerOwner = testData.issuerOwner;
+    issuerOwnerAddress = await issuerOwner.getAddress();
+  });
 
-//   it.skip(`should check for regular campaign:
-//         - can be closed if 1 wei left until softcap
-//         - can cancel investments by anyone if the campaign has been cancelled
-//         - fails to cancel investments by anyone if the campaign is still active
-//         - anyone can process someone's investment if the approval exists
-//         - anyone can invest for someone else
-//         - i can invest for myself
-//         - noone can take my approval and process investment as his own
-//   `, async function () {
-//       /**
-//        * Configuration:
-//        *   asset supply: 1M tokens
-//        *   asset precision: 10 ** 18
-//        *   asset token amount for sale (wei): 190270270270270270270270
-//        *   stablecoin precision: 10 ** 6 
-//        *   soft cap (wei): 2111999997
-//        *   price per token: 111
-//        *   min per user investment (wei): 550000000
-//        *   max per user investment (wei): 2000000000
-//        * 
-//        * Two investors participating in following usdc amounts (wei):
-//        *   investor 1: 552299999
-//        *   investor 2: 1559699997
-//        */
-      
-//       const ASSET_TYPE = "AssetSimple";
-//       const CAMPAIGN_TYPE = "CfManagerSoftcap";
-//       const issuerOwnerAddress = await testData.issuerOwner.getAddress();
-//       const treasuryAddress = await testData.treasury.getAddress();
+  it(`should check for regular campaign:
+        - anyone can process someone's investment if the approval exists
+        - anyone can invest for someone else
+        - i can invest for myself
+        - noone can take my approval and process investment as his own
+  `, async function () {
+    const asset = await helpers.createAsset(
+      issuerOwnerAddress,
+      testData.issuer,
+      "test-asset-1",
+      1000000,
+      false, true, true,
+      "Test Asset",
+      "TSTA",
+      "ipfs-info-hash",
+      testData.assetFactory,
+      testData.nameRegistry,
+      testData.apxRegistry
+    );
 
-//       const frankAddress = await testData.frank.getAddress(); 
-//       const aliceAddress = await testData.alice.getAddress();
-    
-//       //// Frank calls approve and investForBeneficiary() by himself
+    const campaign = await createCampaign(
+      issuerOwnerAddress,
+      "regular-campaign-successful-1",
+      asset,
+      1000,             // $1 price per token
+      10000000,         // $10 softCap (taken from real example)
+      10000000,         // $10 min per user investment
+      2000000000,       // $2000 max per user investment
+      true, "",
+      testData.cfManagerFactory,
+      testData.nameRegistry,
+      testData.feeManager
+    );
+    await asset.connect(issuerOwner).transfer(
+      campaign.address,
+      BigNumber.from("1000000000000000000000") // tranfers 1k tokens for sale (1000 * 10e18)
+    );
 
-//       //// Alice tries to cancel Frank's investment (should fail since the campaign is active)
+    /////////// TEST invest(spender, beneficiary) POSSIBLE SCENARIOS ///////////
+    const investmentAmount = 100 // $100
+    const investmentAmountWei = await helpers.parseStablecoin(investmentAmount, testData.stablecoin);
 
-//       //// Frank cancels his investment
+    //// invest() case 1: A invest for A (spends A's funds - ok)
+    const walletA1 = ethers.Wallet.createRandom().connect(ethers.provider);
+    const addressA1 = await walletA1.getAddress();
+    await testData.issuerOwner.sendTransaction({
+      to: addressA1,
+      value: ethers.utils.parseEther("0.1")
+    });
+    await testData.stablecoin.transfer(addressA1, investmentAmountWei);
+    await expect(
+      helpers.investForBeneficiary(walletA1, walletA1, campaign, testData.stablecoin, investmentAmount)
+    ).to.be.revertedWith("CfManagerSoftcap: Wallet not whitelisted.");
+    await testData.walletApproverService.connect(testData.walletApprover).approveWallet(testData.issuer.address, addressA1);
+    await helpers.investForBeneficiary(walletA1, walletA1, campaign, testData.stablecoin, investmentAmount, walletA1);
+    expect(await campaign.investmentAmount(addressA1)).to.be.equal(investmentAmountWei);
+    await campaign.connect(walletA1).cancelInvestment();
+    expect(await testData.stablecoin.balanceOf(addressA1)).to.be.equal(investmentAmountWei);
 
-//       //// Frank calls approve and invest() by himself
+    //// invest() case 2: A invests for B (spends B's funds - ok)
+    const walletA2 = ethers.Wallet.createRandom().connect(ethers.provider);
+    const addressA2 = await walletA2.getAddress();
+    await testData.issuerOwner.sendTransaction({
+      to: addressA2,
+      value: ethers.utils.parseEther("0.1")
+    });
+    const walletB2 = ethers.Wallet.createRandom().connect(ethers.provider);
+    const addressB2 = await walletB2.getAddress();
+    await testData.issuerOwner.sendTransaction({
+      to: addressB2,
+      value: ethers.utils.parseEther("0.1")
+    });
+    await testData.stablecoin.transfer(addressB2, investmentAmountWei);
+    await expect(
+      helpers.investForBeneficiary(walletB2, walletB2, campaign, testData.stablecoin, investmentAmount, walletA2)
+    ).to.be.revertedWith("CfManagerSoftcap: Wallet not whitelisted.");
+    await testData.walletApproverService.connect(testData.walletApprover).approveWallet(testData.issuer.address, addressB2);
+    await helpers.investForBeneficiary(walletB2, walletB2, campaign, testData.stablecoin, investmentAmount, walletA2)
+    expect(await campaign.investmentAmount(addressB2)).to.be.equal(investmentAmountWei);
+    await campaign.connect(walletB2).cancelInvestment();
+    expect(await testData.stablecoin.balanceOf(addressB2)).to.be.equal(investmentAmountWei);
 
-//       //// Alice calls approve and Frank tries to process Alice's investment as his own (should fail)
+    //// invest() case 3: A invests for B (spends A's funds - ok)
+    const walletA3 = ethers.Wallet.createRandom().connect(ethers.provider);
+    const addressA3 = await walletA3.getAddress();
+    await testData.issuerOwner.sendTransaction({
+      to: addressA3,
+      value: ethers.utils.parseEther("0.1")
+    });
+    const walletB3 = ethers.Wallet.createRandom().connect(ethers.provider);
+    const addressB3 = await walletB3.getAddress();
+    await testData.issuerOwner.sendTransaction({
+      to: addressB3,
+      value: ethers.utils.parseEther("0.1")
+    });
+    await testData.stablecoin.transfer(addressA3, investmentAmountWei);
+    await expect(
+      helpers.investForBeneficiary(walletA3, walletB3, campaign, testData.stablecoin, investmentAmount, walletA3)
+    ).to.be.revertedWith("CfManagerSoftcap: Wallet not whitelisted.");
+    await testData.walletApproverService.connect(testData.walletApprover).approveWallet(testData.issuer.address, addressB3);
+    await helpers.investForBeneficiary(walletA3, walletB3, campaign, testData.stablecoin, investmentAmount, walletA3)
+    expect(await campaign.investmentAmount(addressB3)).to.be.equal(investmentAmountWei);
+    await campaign.connect(walletB3).cancelInvestment();
+    expect(await testData.stablecoin.balanceOf(addressB3)).to.be.equal(investmentAmountWei);
 
-//       //// Frank processes Alice's investment
+    //// invest() case 4: A invests for A (spends B's funds - not ok, should fail)
+    const walletA4 = ethers.Wallet.createRandom().connect(ethers.provider);
+    const addressA4 = await walletA4.getAddress();
+    await testData.issuerOwner.sendTransaction({
+      to: addressA4,
+      value: ethers.utils.parseEther("0.1")
+    });
+    const walletB4 = ethers.Wallet.createRandom().connect(ethers.provider);
+    const addressB4 = await walletB4.getAddress();
+    await testData.issuerOwner.sendTransaction({
+      to: addressB4,
+      value: ethers.utils.parseEther("0.1")
+    });
+    await testData.stablecoin.transfer(addressB4, investmentAmountWei);
+    await expect(
+      helpers.investForBeneficiary(walletB4, walletA4, campaign, testData.stablecoin, investmentAmount, walletA4)
+    ).to.be.revertedWith("CfManagerSoftcap: Only spender can decide to book the investment on somone else.")
+  });
 
-//       const aliceInvestment = 100000;
-//       const aliceInvestmentWei = ethers.utils.parseEther(aliceInvestment.toString());
-//       await testData.stablecoin.transfer(frankAddress, aliceInvestmentWei);
-//       await testData.walletApproverService.connect(testData.walletApprover)
-//           .approveWallet(testData.issuer.address, aliceAddress);
+  it('is possible to close the campaign if 1 wei left to be funded (or such a small amount not representable by the token amount)', async () => {
+    /**
+    * Configuration:
+    *   asset supply: 1M tokens
+    *   asset precision: 10 ** 18
+    *   asset token amount for sale (wei): 190270270270270270270270
+    *   stablecoin precision: 10 ** 6 
+    *   soft cap (wei): 2111999997
+    *   price per token: 111
+    *   min per user investment (wei): 550000000
+    *   max per user investment (wei): 2000000000
+    * 
+    * Two investors participating in following usdc amounts (wei):
+    *   investor 1: 552299999
+    *   investor 2: 1559699999
+    */
+    const asset = await helpers.createAsset(
+      issuerOwnerAddress,
+      testData.issuer,
+      "test-asset-2",
+      1000000,
+      false, true, true,
+      "Test Asset",
+      "TSTA",
+      "ipfs-info-hash",
+      testData.assetFactory,
+      testData.nameRegistry,
+      testData.apxRegistry
+    );
 
-//       //// Frank invests $100k USDC credited to the Alice's wallet.
-//       await helpers.investForBeneficiary(
-//         testData.frank,
-//         testData.alice,
-//         testData.cfManagerVesting,
-//         testData.stablecoin,
-//         aliceInvestment
-//       );
+    // data taken from real example
+    const campaign = await createCampaign(
+      issuerOwnerAddress,
+      "regular-campaign-successful-2",
+      asset,
+      111,             // $0.111 price per token
+      2111999997,      // ~$2112 softCap (taken from real example)
+      550000000,       // $550 min per user investment
+      2000000000,      // $2000 max per user investment
+      true, "",
+      testData.cfManagerFactory,
+      testData.nameRegistry,
+      testData.feeManager
+    );
+    await asset.connect(issuerOwner).transfer(campaign.address, BigNumber.from("190270270270270270270270"));
 
-//     });
+    const frankAddress = await testData.frank.getAddress();
+    const frankInvestment = BigNumber.from("552299999");
+    await testData.walletApproverService.connect(testData.walletApprover).approveWallet(testData.issuer.address, frankAddress);
+    await testData.stablecoin.transfer(frankAddress, frankInvestment);
+    await testData.stablecoin.connect(testData.frank).approve(campaign.address, frankInvestment);
+    await campaign.connect(testData.frank).invest(frankInvestment);
 
-// });
+    const aliceAddress = await testData.alice.getAddress();
+    const aliceInvestment = BigNumber.from("1559699999");
+    await testData.walletApproverService.connect(testData.walletApprover).approveWallet(testData.issuer.address, aliceAddress);
+    await testData.stablecoin.transfer(aliceAddress, aliceInvestment);
+    await testData.stablecoin.connect(testData.alice).approve(campaign.address, aliceInvestment);
+    await campaign.connect(testData.alice).invest(aliceInvestment);
+
+    const oneWei = BigNumber.from("1");
+    const commonState = await campaign.commonState();
+    expect(commonState.softCap.sub(commonState.fundsRaised)).to.be.equal(oneWei);
+
+    await testData.stablecoin.transfer(aliceAddress, oneWei);
+    await testData.stablecoin.approve(campaign.address, oneWei);
+    await expect(
+      campaign.connect(testData.alice).invest(oneWei)
+    ).to.be.revertedWith("CfManagerSoftcap: Investment amount too low.")
+
+    // Campaign can be closed although funds raised is 1wei lower than the configured softCap | special case
+    await campaign.connect(issuerOwner).finalize();
+    await campaign.connect(testData.frank).claim(frankAddress);
+    await campaign.connect(testData.alice).claim(aliceAddress);
+
+    const postFinalizationCampaignTokenBalance = await asset.balanceOf(campaign.address);
+    const postFinalizationCampaignUsdcBalance = await testData.stablecoin.balanceOf(campaign.address);
+    expect(postFinalizationCampaignTokenBalance).to.be.equal(0);
+    expect(postFinalizationCampaignUsdcBalance).to.be.equal(0);
+
+    const assetTotalSupply = await asset.totalSupply();
+    const postFinalizationOwnerTokenBalance = await asset.balanceOf(issuerOwnerAddress);
+    const postFinalizationOwnerUsdcBalance = await testData.stablecoin.balanceOf(issuerOwnerAddress);
+    expect(postFinalizationOwnerTokenBalance).to.be.equal(assetTotalSupply.sub(commonState.tokensSold));
+    expect(postFinalizationOwnerUsdcBalance).to.be.equal(commonState.fundsRaised);
+
+    const postFinalizationFrankTokenBalance = await asset.balanceOf(frankAddress);
+    const postFinalizationFrankUsdcBalance = await testData.stablecoin.balanceOf(frankAddress);
+    expect(postFinalizationFrankTokenBalance).to.be.equal(await campaign.tokenAmount(frankAddress));
+    expect(postFinalizationFrankUsdcBalance).to.be.equal(
+      frankInvestment.sub(await campaign.investmentAmount(frankAddress))
+    );
+
+    const postFinalizationAliceTokenBalance = await asset.balanceOf(aliceAddress);
+    const postFinalizationAliceUsdcBalance = await testData.stablecoin.balanceOf(aliceAddress);
+    expect(postFinalizationAliceTokenBalance).to.be.equal(await campaign.tokenAmount(aliceAddress));
+    expect(postFinalizationAliceUsdcBalance).to.be.equal(
+      aliceInvestment.add(oneWei).sub(await campaign.investmentAmount(aliceAddress))
+    );
+  })
+
+  it(`is supported by the campaign to execute following:
+      - can cancel investments by anyone if the campaign has been cancelled
+      - fails to cancel investments by anyone if the campaign is still active`, async () => {
+
+    const asset = await helpers.createAsset(
+      issuerOwnerAddress,
+      testData.issuer,
+      "test-asset-3",
+      1000000,
+      false, true, true,
+      "Test Asset",
+      "TSTA",
+      "ipfs-info-hash",
+      testData.assetFactory,
+      testData.nameRegistry,
+      testData.apxRegistry
+    );
+
+    const campaign = await createCampaign(
+      issuerOwnerAddress,
+      "failed-campaign",
+      asset,
+      1000,             // $1 price per token
+      10000000,         // $10 softCap (taken from real example)
+      10000000,         // $10 min per user investment
+      2000000000,       // $2000 max per user investment
+      true, "",
+      testData.cfManagerFactory,
+      testData.nameRegistry,
+      testData.feeManager
+    );
+    await asset.connect(issuerOwner).transfer(
+      campaign.address,
+      BigNumber.from("1000000000000000000000") // tranfers 1k tokens for sale (1000 * 10e18)
+    );
+
+    const frankAddress = await testData.frank.getAddress();
+    const frankInvestment = await helpers.parseStablecoin("100", testData.stablecoin);
+    await testData.stablecoin.transfer(frankAddress, frankInvestment);
+    await testData.walletApproverService.connect(testData.walletApprover).approveWallet(testData.issuer.address, frankAddress);
+
+    // Frank invests
+    await testData.stablecoin.connect(testData.frank).approve(campaign.address, frankInvestment);
+    await campaign.connect(testData.frank).invest(frankInvestment);
+    expect(
+      await campaign.investmentAmount(frankAddress)
+    ).to.be.equal(frankInvestment);
+
+    // Alice can't cancel investment for Frank (campaign is still ongoing)
+    await expect(
+      campaign.connect(testData.alice).cancelInvestmentFor(frankAddress)
+    ).to.be.revertedWith("CfManagerSoftcapVesting: Can only cancel for somoneone if the campaign has been canceled.");
+
+    // Frank can cancel investment by himself though
+    await campaign.connect(testData.frank).cancelInvestment();
+    expect(
+      await campaign.investmentAmount(frankAddress)
+    ).to.be.equal(0);
+
+    // Frank invests again
+    await testData.stablecoin.connect(testData.frank).approve(campaign.address, frankInvestment);
+    await campaign.connect(testData.frank).invest(frankInvestment);
+    expect(
+      await campaign.investmentAmount(frankAddress)
+    ).to.be.equal(frankInvestment);
+
+    // Project owner cancels the campaign
+    await campaign.connect(issuerOwner).cancelCampaign();
+
+    // Alice can now cancel investment for Frank
+    await campaign.connect(testData.alice).cancelInvestmentFor(frankAddress);
+    expect(
+      await campaign.investmentAmount(frankAddress)
+    ).to.be.equal(0);
+    expect(
+      await testData.stablecoin.balanceOf(campaign.address)
+    ).to.be.equal(0);
+    expect(
+      await asset.balanceOf(campaign.address)
+    ).to.be.equal(0);
+    expect(
+      await testData.stablecoin.balanceOf(frankAddress)
+    ).to.be.equal(frankInvestment);
+  })
+
+});

--- a/util/deployer-service.ts
+++ b/util/deployer-service.ts
@@ -1,11 +1,12 @@
 // @ts-ignore
 import { ethers } from "hardhat";
 import { Contract } from "ethers";
+import { parseStablecoin } from "./helpers";
 
 export async function createIssuerAssetCampaign(
     issuerOwner: String,
     issuerMappedName: String,
-    issuerStablecoin: String,
+    issuerStablecoin: string,
     issuerWalletApprover: String,
     issuerInfo: String,
     assetOwner: String,
@@ -31,11 +32,12 @@ export async function createIssuerAssetCampaign(
     apxRegistry: Contract,
     nameRegistry: Contract
   ): Promise<Array<Contract>> {
+    const stablecoin = await ethers.getContractAt("USDC", issuerStablecoin);
     const assetInitialTokenSupplyWei = ethers.utils.parseEther(assetInitialTokenSupply.toString());
-    const cfManagerSoftcapWei = ethers.utils.parseEther(cfManagerSoftcap.toString());
+    const cfManagerSoftcapWei = await parseStablecoin(cfManagerSoftcap, stablecoin);
     const cfManagerTokensToSellAmountWei = ethers.utils.parseEther(cfManagerTokensToSellAmount.toString());
-    const cfManagerMinInvestmentWei = ethers.utils.parseEther(cfManagerMinInvestment.toString());
-    const cfManagerMaxInvestmentWei = ethers.utils.parseEther(cfManagerMaxInvestment.toString());
+    const cfManagerMinInvestmentWei = await parseStablecoin(cfManagerMinInvestment, stablecoin);
+    const cfManagerMaxInvestmentWei = await parseStablecoin(cfManagerMaxInvestment, stablecoin);
     const deployTx = await deployerService.deployIssuerAssetCampaign(
       [
         issuerFactory.address,
@@ -133,10 +135,12 @@ export async function createIssuerAssetCampaign(
     cfManagerFactory: Contract,
     deployerService: Contract
   ): Promise<Array<Contract>> {
+    const stablecoinAddress = (await issuer.commonState()).stablecoin;
+    const stablecoin = await ethers.getContractAt("USDC", stablecoinAddress);
     const assetInitialTokenSupplyWei = ethers.utils.parseEther(assetInitialTokenSupply.toString());
-    const cfManagerSoftcapWei = ethers.utils.parseEther(cfManagerSoftcap.toString());
-    const cfManagerMinInvestmentWei = ethers.utils.parseEther(cfManagerMinInvestment.toString());
-    const cfManagerMaxInvestmentWei = ethers.utils.parseEther(cfManagerMaxInvestment.toString());
+    const cfManagerSoftcapWei = await parseStablecoin(cfManagerSoftcap, stablecoin);
+    const cfManagerMinInvestmentWei = await parseStablecoin(cfManagerMinInvestment, stablecoin);
+    const cfManagerMaxInvestmentWei = await parseStablecoin(cfManagerMaxInvestment, stablecoin);
     const cfManagerTokensToSellAmountWei = ethers.utils.parseEther(cfManagerTokensToSellAmount.toString());
     const deployTx = await deployerService.deployAssetCampaign(
       [
@@ -198,7 +202,7 @@ export async function createIssuerAssetCampaign(
 export async function createIssuerAssetTransferableCampaign(
     issuerOwner: String,
     issuerMappedName: String,
-    issuerStablecoin: String,
+    issuerStablecoin: string,
     issuerWalletApprover: String,
     issuerInfo: String,
     assetOwner: String,
@@ -225,11 +229,12 @@ export async function createIssuerAssetTransferableCampaign(
     cfManagerFactory: Contract,
     deployerService: Contract
   ): Promise<Array<Contract>> {
+    const stablecoin = await ethers.getContractAt("USDC", issuerStablecoin);
     const assetInitialTokenSupplyWei = ethers.utils.parseEther(assetInitialTokenSupply.toString());
-    const cfManagerSoftcapWei = ethers.utils.parseEther(cfManagerSoftcap.toString());
+    const cfManagerSoftcapWei = await parseStablecoin(cfManagerSoftcap, stablecoin);
     const cfManagerTokensToSellAmountWei = ethers.utils.parseEther(cfManagerTokensToSellAmount.toString());
-    const cfManagerMinInvestmentWei = ethers.utils.parseEther(cfManagerMinInvestment.toString());
-    const cfManagerMaxInvestmentWei = ethers.utils.parseEther(cfManagerMaxInvestment.toString());
+    const cfManagerMinInvestmentWei = await parseStablecoin(cfManagerMinInvestment, stablecoin);
+    const cfManagerMaxInvestmentWei = await parseStablecoin(cfManagerMaxInvestment, stablecoin);
     const deployTx = await deployerService.deployIssuerAssetTransferableCampaign(
       [
         issuerFactory.address,
@@ -328,10 +333,12 @@ export async function createAssetTransferableCampaign(
     cfManagerFactory: Contract,
     deployerService: Contract
   ): Promise<Array<Contract>> {
+    const stablecoinAddress = (await issuer.commonState()).stablecoin;
+    const stablecoin = await ethers.getContractAt("USDC", stablecoinAddress);
     const assetInitialTokenSupplyWei = ethers.utils.parseEther(assetInitialTokenSupply.toString());
-    const cfManagerSoftcapWei = ethers.utils.parseEther(cfManagerSoftcap.toString());
-    const cfManagerMinInvestmentWei = ethers.utils.parseEther(cfManagerMinInvestment.toString());
-    const cfManagerMaxInvestmentWei = ethers.utils.parseEther(cfManagerMaxInvestment.toString());
+    const cfManagerSoftcapWei = await parseStablecoin(cfManagerSoftcap, stablecoin);
+    const cfManagerMinInvestmentWei = await parseStablecoin(cfManagerMinInvestment, stablecoin);
+    const cfManagerMaxInvestmentWei = await parseStablecoin(cfManagerMaxInvestment, stablecoin);
     const cfManagerTokensToSellAmountWei = ethers.utils.parseEther(cfManagerTokensToSellAmount.toString());
     const deployTx = await deployerService.deployAssetTransferableCampaign(
       [
@@ -413,10 +420,12 @@ export async function createAssetSimpleCampaignVesting(
   cfManagerVestingFactory: Contract,
   deployerService: Contract
 ): Promise<Array<Contract>> {
+  const stablecoinAddress = (await issuer.commonState()).stablecoin;
+  const stablecoin = await ethers.getContractAt("USDC", stablecoinAddress);
   const assetInitialTokenSupplyWei = ethers.utils.parseEther(assetInitialTokenSupply.toString());
-  const cfManagerSoftcapWei = ethers.utils.parseEther(cfManagerSoftcap.toString());
-  const cfManagerMinInvestmentWei = ethers.utils.parseEther(cfManagerMinInvestment.toString());
-  const cfManagerMaxInvestmentWei = ethers.utils.parseEther(cfManagerMaxInvestment.toString());
+  const cfManagerSoftcapWei = await parseStablecoin(cfManagerSoftcap, stablecoin);
+  const cfManagerMinInvestmentWei = await parseStablecoin(cfManagerMinInvestment, stablecoin);
+  const cfManagerMaxInvestmentWei = await parseStablecoin(cfManagerMaxInvestment, stablecoin);
   const cfManagerTokensToSellAmountWei = ethers.utils.parseEther(cfManagerTokensToSellAmount.toString());
   const deployTx = await deployerService.deployAssetSimpleCampaignVesting(
     [

--- a/util/helpers.ts
+++ b/util/helpers.ts
@@ -244,6 +244,7 @@ export async function createAsset(
   issuer: Contract,
   mappedName: String,
   initialTokenSupply: Number,
+  transferable: boolean,
   whitelistRequiredForRevenueClaim: boolean,
   whitelistRequiredForLiquidationClaim: boolean,
   name: String,
@@ -253,18 +254,20 @@ export async function createAsset(
   nameRegistry: Contract,
   apxRegistry: Contract
 ): Promise<Contract> {
-  const createAssetTx = await assetFactory.create(
-    owner,
-    issuer.address,
-    apxRegistry.address,
-    nameRegistry.address,
-    mappedName,
-    ethers.utils.parseEther(initialTokenSupply.toString()),
-    whitelistRequiredForRevenueClaim,
-    whitelistRequiredForLiquidationClaim,
-    name,
-    symbol,
-    info
+  const createAssetTx = await assetFactory.create([
+      owner,
+      issuer.address,
+      apxRegistry.address,
+      nameRegistry.address,
+      mappedName,
+      ethers.utils.parseEther(initialTokenSupply.toString()),
+      transferable,
+      whitelistRequiredForRevenueClaim,
+      whitelistRequiredForLiquidationClaim,
+      name,
+      symbol,
+      info
+    ]
   );
   const receipt = await ethers.provider.waitForTransaction(createAssetTx.hash);
   for (const log of receipt.logs) {
@@ -408,12 +411,12 @@ export async function invest(investor: Signer, cfManager: Contract, stablecoin: 
  * @param stablecoin Stablecoin contract instance to be used for payment
  * @param amount Amount of the stablecoin to be invested
  */
- export async function investForBeneficiary(spender: Signer, beneficiary: Signer, cfManager: Contract, stablecoin: Contract, amount: Number) {
+ export async function investForBeneficiary(spender: Signer, beneficiary: Signer, cfManager: Contract, stablecoin: Contract, amount: Number, caller: Signer = ethers.provider.getSigner()) {
   const amountWei = await parseStablecoin(amount, stablecoin);
   const beneficiaryAddress = await beneficiary.getAddress();
   const spenderAddress = await spender.getAddress();
   await stablecoin.connect(spender).approve(cfManager.address, amountWei);
-  await cfManager.connect(spender).investForBeneficiary(spenderAddress, beneficiaryAddress, amountWei);
+  await cfManager.connect(caller).investForBeneficiary(spenderAddress, beneficiaryAddress, amountWei);
 }
 
 /**

--- a/util/helpers.ts
+++ b/util/helpers.ts
@@ -397,12 +397,12 @@ export async function invest(investor: Signer, cfManager: Contract, stablecoin: 
  * @param stablecoin Stablecoin contract instance to be used for payment
  * @param amount Amount of the stablecoin to be invested
  */
- export async function investForBeneficiary(caller: Signer, spender: Signer, beneficiary: Signer, cfManager: Contract, stablecoin: Contract, amount: Number) {
+ export async function investForBeneficiary(spender: Signer, beneficiary: Signer, cfManager: Contract, stablecoin: Contract, amount: Number) {
   const amountWei = ethers.utils.parseEther(amount.toString());
   const beneficiaryAddress = await beneficiary.getAddress();
   const spenderAddress = await spender.getAddress();
   await stablecoin.connect(spender).approve(cfManager.address, amountWei);
-  await cfManager.connect(caller).investForBeneficiary(spenderAddress, beneficiaryAddress, amountWei);
+  await cfManager.connect(spender).investForBeneficiary(spenderAddress, beneficiaryAddress, amountWei);
 }
 
 /**

--- a/util/helpers.ts
+++ b/util/helpers.ts
@@ -489,11 +489,12 @@ export async function cancelCampaign(owner: Signer, cfManager: Contract) {
  * @param stablecoin Stablecoin contract instance to be used as the payment method
  * @param amount Amount (in stablecoin) to be distributed as revenue
  * @param payoutDescription Description for this revenue payout
+ * @param payoutDescription Addresses to ignore when distributing revenue (for example: liquidity pools, treasury, token owner...)
  */
-export async function createPayout(owner: Signer, snapshotDistributor: Contract, stablecoin: Contract, amount: Number, payoutDescription: String) {
+export async function createPayout(owner: Signer, snapshotDistributor: Contract, stablecoin: Contract, amount: Number, payoutDescription: String, ignoredAddresses: String[] = []) {
   const amountWei = await parseStablecoin(amount, stablecoin);
   await stablecoin.connect(owner).approve(snapshotDistributor.address, amountWei);
-  await snapshotDistributor.connect(owner).createPayout(payoutDescription, stablecoin.address, amountWei, []);
+  await snapshotDistributor.connect(owner).createPayout(payoutDescription, stablecoin.address, amountWei, ignoredAddresses);
 }
 
 /**


### PR DESCRIPTION
add public cancelInvest(investor) if campaign is canceled

enable campaign finalization if softCap almost reached but value remaining too small to be detected

make Claim() event signature on vesting campaign to be the same as in regular campaign

fix investForBeneficiary() bug when caller credits approver's investment to his wallet