### PR TITLE
SD-575: add more info to payout events

### DIFF
--- a/contracts/managers/payout-manager/IPayoutManager.sol
+++ b/contracts/managers/payout-manager/IPayoutManager.sol
@@ -30,8 +30,8 @@ interface IPayoutManager is IVersioned {
     //  EVENTS
     //------------------------
     event PayoutCreated(uint256 payoutId, address indexed payoutOwner, IERC20 asset, IERC20 rewardAsset, uint256 totalRewardAmount);
-    event PayoutCanceled(uint256 payoutId, IERC20 asset);
-    event PayoutClaimed(uint256 payoutId, address indexed wallet, uint256 balance, uint256 payoutAmount);
+    event PayoutCanceled(uint256 payoutId, address indexed payoutOwner, IERC20 asset, IERC20 rewardAsset, uint256 remainingRewardAmount);
+    event PayoutClaimed(uint256 payoutId, address indexed wallet, IERC20 asset, uint256 balance, IERC20 rewardAsset, uint256 payoutAmount);
 
     //------------------------
     //  READ-ONLY FUNCTIONS

--- a/contracts/managers/payout-manager/IPayoutManager.sol
+++ b/contracts/managers/payout-manager/IPayoutManager.sol
@@ -29,9 +29,9 @@ interface IPayoutManager is IVersioned {
     //------------------------
     //  EVENTS
     //------------------------
-    event PayoutCreated(uint256 payoutId, address indexed payoutOwner, IERC20 asset, IERC20 rewardAsset, uint256 totalRewardAmount);
-    event PayoutCanceled(uint256 payoutId, address indexed payoutOwner, IERC20 asset, IERC20 rewardAsset, uint256 remainingRewardAmount);
-    event PayoutClaimed(uint256 payoutId, address indexed wallet, IERC20 asset, uint256 balance, IERC20 rewardAsset, uint256 payoutAmount);
+    event PayoutCreated(uint256 payoutId, address indexed payoutOwner, IERC20 asset, IERC20 rewardAsset, uint256 totalRewardAmount, uint256 timestamp);
+    event PayoutCanceled(uint256 payoutId, address indexed payoutOwner, IERC20 asset, IERC20 rewardAsset, uint256 remainingRewardAmount, uint256 timestamp);
+    event PayoutClaimed(uint256 payoutId, address indexed wallet, IERC20 asset, uint256 balance, IERC20 rewardAsset, uint256 payoutAmount, uint256 timestamp);
 
     //------------------------
     //  READ-ONLY FUNCTIONS

--- a/contracts/managers/payout-manager/PayoutManager.sol
+++ b/contracts/managers/payout-manager/PayoutManager.sol
@@ -143,7 +143,7 @@ contract PayoutManager is IPayoutManager {
         // transfer reward asset
         _createPayout.rewardAsset.transferFrom(payoutOwner, address(this), _createPayout.totalRewardAmount);
 
-        emit PayoutCreated(payout.payoutId, payoutOwner, _createPayout.asset, _createPayout.rewardAsset, _createPayout.totalRewardAmount);
+        emit PayoutCreated(payout.payoutId, payoutOwner, _createPayout.asset, _createPayout.rewardAsset, _createPayout.totalRewardAmount, block.timestamp);
 
         return payout.payoutId;
     }
@@ -161,7 +161,7 @@ contract PayoutManager is IPayoutManager {
         // transfer all remaining reward funds to the payout owner
         payout.rewardAsset.transfer(payout.payoutOwner, remainingRewardAmount);
 
-        emit PayoutCanceled(_payoutId, payout.payoutOwner, payout.asset, payout.rewardAsset, remainingRewardAmount);
+        emit PayoutCanceled(_payoutId, payout.payoutOwner, payout.asset, payout.rewardAsset, remainingRewardAmount, block.timestamp);
     }
 
     function claim(
@@ -207,6 +207,6 @@ contract PayoutManager is IPayoutManager {
         // send reward funds
         payout.rewardAsset.transfer(_wallet, payoutAmount);
 
-        emit PayoutClaimed(_payoutId, _wallet, payout.asset, _balance, payout.rewardAsset, payoutAmount);
+        emit PayoutClaimed(_payoutId, _wallet, payout.asset, _balance, payout.rewardAsset, payoutAmount, block.timestamp);
     }
 }

--- a/contracts/managers/payout-manager/PayoutManager.sol
+++ b/contracts/managers/payout-manager/PayoutManager.sol
@@ -161,7 +161,7 @@ contract PayoutManager is IPayoutManager {
         // transfer all remaining reward funds to the payout owner
         payout.rewardAsset.transfer(payout.payoutOwner, remainingRewardAmount);
 
-        emit PayoutCanceled(_payoutId, payout.asset);
+        emit PayoutCanceled(_payoutId, payout.payoutOwner, payout.asset, payout.rewardAsset, remainingRewardAmount);
     }
 
     function claim(
@@ -207,6 +207,6 @@ contract PayoutManager is IPayoutManager {
         // send reward funds
         payout.rewardAsset.transfer(_wallet, payoutAmount);
 
-        emit PayoutClaimed(_payoutId, _wallet, _balance, payoutAmount);
+        emit PayoutClaimed(_payoutId, _wallet, payout.asset, _balance, payout.rewardAsset, payoutAmount);
     }
 }

--- a/test/managers/payout-manager-test.ts
+++ b/test/managers/payout-manager-test.ts
@@ -130,7 +130,8 @@ describe("Payout Manager test", function () {
             expected.owner,
             expected.asset,
             rewardAsset.address,
-            expected.totalReward
+            expected.totalReward,
+            async () => (await createPayout).timestamp
         );
     }
 
@@ -506,15 +507,16 @@ describe("Payout Manager test", function () {
         verifyPayoutInfo(ownerPayouts[0], payout);
 
         // cancel payout
-        const cencelPayout = payoutManager.connect(payoutOwner1).cancelPayout(payout.id);
+        const cancelPayout = payoutManager.connect(payoutOwner1).cancelPayout(payout.id);
 
         // verify cancel payout event
-        await expect(cencelPayout).to.emit(payoutManager, "PayoutCanceled").withArgs(
+        await expect(cancelPayout).to.emit(payoutManager, "PayoutCanceled").withArgs(
             payout.id,
             payout.owner,
             payout.asset,
             payoutInfo.rewardAsset,
-            payout.remainingReward
+            payout.remainingReward,
+            async () => (await cancelPayout).timestamp
         );
 
         // verify funds are returned to owner
@@ -582,15 +584,16 @@ describe("Payout Manager test", function () {
         expect(balance).to.be.equal(balances[0]);
 
         // cancel payout
-        const cencelPayout = payoutManager.connect(payoutOwner1).cancelPayout(payout.id);
+        const cancelPayout = payoutManager.connect(payoutOwner1).cancelPayout(payout.id);
 
         // verify cancel payout event
-        await expect(cencelPayout).to.emit(payoutManager, "PayoutCanceled").withArgs(
+        await expect(cancelPayout).to.emit(payoutManager, "PayoutCanceled").withArgs(
             payout.id,
             payout.owner,
             payout.asset,
             payoutInfo.rewardAsset,
-            payout.remainingReward - balances[0] // minus claimed reward
+            payout.remainingReward - balances[0], // minus claimed reward
+            async () => (await cancelPayout).timestamp
         );
 
         // verify funds are returned to owner
@@ -661,15 +664,16 @@ describe("Payout Manager test", function () {
         await verifyCreatePayoutEvent(createPayout, payout);
 
         // cancel payout
-        const cencelPayout = payoutManager.connect(payoutOwner1).cancelPayout(payout.id);
+        const cancelPayout = payoutManager.connect(payoutOwner1).cancelPayout(payout.id);
 
         // verify cancel payout event
-        await expect(cencelPayout).to.emit(payoutManager, "PayoutCanceled").withArgs(
+        await expect(cancelPayout).to.emit(payoutManager, "PayoutCanceled").withArgs(
             payout.id,
             payout.owner,
             payout.asset,
             rewardAsset.address,
-            payout.remainingReward
+            payout.remainingReward,
+            async () => (await cancelPayout).timestamp
         );
 
         // verify funds are returned to owner
@@ -735,15 +739,16 @@ describe("Payout Manager test", function () {
         verifyPayoutInfo(ownerPayouts[0], payout);
 
         // cancel payout
-        const cencelPayout = payoutManager.connect(payoutOwner1).cancelPayout(payout.id);
+        const cancelPayout = payoutManager.connect(payoutOwner1).cancelPayout(payout.id);
 
         // verify cancel payout event
-        await expect(cencelPayout).to.emit(payoutManager, "PayoutCanceled").withArgs(
+        await expect(cancelPayout).to.emit(payoutManager, "PayoutCanceled").withArgs(
             payout.id,
             payout.owner,
             payout.asset,
             rewardAsset.address,
-            payout.remainingReward
+            payout.remainingReward,
+            async () => (await cancelPayout).timestamp
         );
 
         // verify funds are returned to owner

--- a/test/managers/payout-manager-test.ts
+++ b/test/managers/payout-manager-test.ts
@@ -511,7 +511,10 @@ describe("Payout Manager test", function () {
         // verify cancel payout event
         await expect(cencelPayout).to.emit(payoutManager, "PayoutCanceled").withArgs(
             payout.id,
-            payout.asset
+            payout.owner,
+            payout.asset,
+            payoutInfo.rewardAsset,
+            payout.remainingReward
         );
 
         // verify funds are returned to owner
@@ -584,7 +587,10 @@ describe("Payout Manager test", function () {
         // verify cancel payout event
         await expect(cencelPayout).to.emit(payoutManager, "PayoutCanceled").withArgs(
             payout.id,
-            payout.asset
+            payout.owner,
+            payout.asset,
+            payoutInfo.rewardAsset,
+            payout.remainingReward - balances[0] // minus claimed reward
         );
 
         // verify funds are returned to owner
@@ -660,7 +666,10 @@ describe("Payout Manager test", function () {
         // verify cancel payout event
         await expect(cencelPayout).to.emit(payoutManager, "PayoutCanceled").withArgs(
             payout.id,
-            payout.asset
+            payout.owner,
+            payout.asset,
+            rewardAsset.address,
+            payout.remainingReward
         );
 
         // verify funds are returned to owner
@@ -731,7 +740,10 @@ describe("Payout Manager test", function () {
         // verify cancel payout event
         await expect(cencelPayout).to.emit(payoutManager, "PayoutCanceled").withArgs(
             payout.id,
-            payout.asset
+            payout.owner,
+            payout.asset,
+            rewardAsset.address,
+            payout.remainingReward
         );
 
         // verify funds are returned to owner


### PR DESCRIPTION
Adds more info to payout events - this is needed in report service to correctly show user transaction history.